### PR TITLE
Add a write permissiong to the release workflow

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -21,6 +21,9 @@ on:
     tags:
     - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
 
   release:


### PR DESCRIPTION
As it was mentioned [here](https://developer.hashicorp.com/terraform/tutorials/providers/provider-release-publish#add-github-action-workflow), the [release yaml ](https://github.com/hashicorp/terraform-provider-scaffolding/blob/main/.github/workflows/release.yml#L17)should include the write permissions 