### PR TITLE
Matching rosa

### DIFF
--- a/provider/cluster_rosa_classic_resource.go
+++ b/provider/cluster_rosa_classic_resource.go
@@ -277,6 +277,11 @@ func (t *ClusterRosaClassicResourceType) GetSchema(ctx context.Context) (result 
 						Type:        types.StringType,
 						Optional:    true,
 					},
+					"additional_trust_bundle": {
+						Description: "a string contains contains a PEM-encoded X.509 certificate bundle that will be added to the nodes' trusted certificate store.",
+						Type:        types.StringType,
+						Optional:    true,
+					},
 				}),
 				Optional: true,
 				PlanModifiers: []tfsdk.AttributePlanModifier{
@@ -551,6 +556,9 @@ func createClassicClusterObject(ctx context.Context,
 	if state.Proxy != nil {
 		proxy.HTTPProxy(state.Proxy.HttpProxy.Value)
 		proxy.HTTPSProxy(state.Proxy.HttpsProxy.Value)
+		if !state.Proxy.AdditionalTrustBundle.Unknown && !state.Proxy.AdditionalTrustBundle.Null {
+			builder.AdditionalTrustBundle(state.Proxy.AdditionalTrustBundle.Value)
+		}
 		builder.Proxy(proxy)
 	}
 
@@ -985,6 +993,14 @@ func populateRosaClassicClusterState(ctx context.Context, object *cmv1.Cluster, 
 			Value: proxy.HTTPSProxy(),
 		}
 	}
+
+	trustBundle, ok := object.GetAdditionalTrustBundle()
+	if ok {
+		state.Proxy.AdditionalTrustBundle = types.String{
+			Value: trustBundle,
+		}
+	}
+
 	machineCIDR, ok := object.Network().GetMachineCIDR()
 	if ok {
 		state.MachineCIDR = types.String{

--- a/provider/cluster_rosa_classic_state.go
+++ b/provider/cluster_rosa_classic_state.go
@@ -33,6 +33,7 @@ type ClusterRosaClassicState struct {
 	MaxReplicas               types.Int64  `tfsdk:"max_replicas"`
 	CloudRegion               types.String `tfsdk:"cloud_region"`
 	ComputeMachineType        types.String `tfsdk:"compute_machine_type"`
+	ComputeLabels             types.Map    `tfsdk:"compute_labels"`
 	Replicas                  types.Int64  `tfsdk:"replicas"`
 	ConsoleURL                types.String `tfsdk:"console_url"`
 	HostPrefix                types.Int64  `tfsdk:"host_prefix"`

--- a/provider/cluster_state.go
+++ b/provider/cluster_state.go
@@ -50,7 +50,8 @@ type ClusterState struct {
 }
 
 type Proxy struct {
-	HttpProxy  types.String `tfsdk:"http_proxy"`
-	HttpsProxy types.String `tfsdk:"https_proxy"`
-	NoProxy    types.String `tfsdk:"no_proxy"`
+	HttpProxy             types.String `tfsdk:"http_proxy"`
+	HttpsProxy            types.String `tfsdk:"https_proxy"`
+	NoProxy               types.String `tfsdk:"no_proxy"`
+	AdditionalTrustBundle types.String `tfsdk:"additional_trust_bundle"`
 }

--- a/provider/machine_pool_state.go
+++ b/provider/machine_pool_state.go
@@ -29,4 +29,12 @@ type MachinePoolState struct {
 	AutoScalingEnabled types.Bool   `tfsdk:"autoscaling_enabled"`
 	MinReplicas        types.Int64  `tfsdk:"min_replicas"`
 	MaxReplicas        types.Int64  `tfsdk:"max_replicas"`
+	Taints             []Taints     `tfsdk:"taints"`
+	Labels             types.Map    `tfsdk:"labels"`
+}
+
+type Taints struct {
+	Key          types.String `tfsdk:"key"`
+	Value        types.String `tfsdk:"value"`
+	ScheduleType types.String `tfsdk:"schedule_type"`
 }

--- a/subsystem/cluster_resource_rosa_test.go
+++ b/subsystem/cluster_resource_rosa_test.go
@@ -98,6 +98,7 @@ var _ = Describe("Cluster creation", func() {
 				VerifyJQ(`.product.id`, "rosa"),
 				VerifyJQ(`.proxy.http_proxy`, "http://proxy.com"),
 				VerifyJQ(`.proxy.https_proxy`, "http://proxy.com"),
+				VerifyJQ(`.additional_trust_bundle`, "123"),
 				RespondWithPatchedJSON(http.StatusOK, template, `[
 					{
 					  "op": "add",
@@ -105,6 +106,13 @@ var _ = Describe("Cluster creation", func() {
 					  "value": {						  
 						  "http_proxy" : "http://proxy.com",
 						  "https_proxy" : "http://proxy.com"
+					  }
+					},
+					{
+					  "op": "add",
+					  "path": "/",
+					  "value": {
+						  "additional_trust_bundle" : "123"
 					  }
 					},
 					{
@@ -129,6 +137,7 @@ var _ = Describe("Cluster creation", func() {
 			proxy = {
 				http_proxy = "http://proxy.com",
 				https_proxy = "http://proxy.com",
+				additional_trust_bundle = "123",
 			}			
 		  }
 		`)
@@ -252,6 +261,8 @@ var _ = Describe("Cluster creation", func() {
 				VerifyJQ(`.nodes.autoscale_compute.kind`, "MachinePoolAutoscaling"),
 				VerifyJQ(`.nodes.autoscale_compute.max_replicas`, float64(4)),
 				VerifyJQ(`.nodes.autoscale_compute.min_replicas`, float64(2)),
+				VerifyJQ(`.nodes.compute_labels.label_key1`, "label_value1"),
+				VerifyJQ(`.nodes.compute_labels.label_key2`, "label_value2"),
 				RespondWithPatchedJSON(http.StatusOK, template, `[
 					{
 					  "op": "add",
@@ -280,6 +291,10 @@ var _ = Describe("Cluster creation", func() {
 						},
 						"compute_machine_type": {
 							"id": "r5.xlarge"
+						},
+						"compute_labels": {
+							"label_key1": "label_value1",
+				    		"label_key2": "label_value2"
 						}
 					  }
 					}
@@ -296,6 +311,10 @@ var _ = Describe("Cluster creation", func() {
 			autoscaling_enabled = "true"
 			min_replicas = "2"
 			max_replicas = "4"
+			compute_labels = {
+				"label_key1" = "label_value1", 
+				"label_key2" = "label_value2"
+			}
 			sts = {
 				role_arn = "arn:aws:iam::account-id:role/ManagedOpenShift-Installer-Role",
 				support_role_arn = "arn:aws:iam::account-id:role/ManagedOpenShift-Support-Role",
@@ -342,6 +361,10 @@ var _ = Describe("Cluster creation", func() {
 						},
 						"compute_machine_type": {
 							"id": "r5.xlarge"
+						},
+						"compute_labels": {
+							"label_key1": "label_value1",
+				    		"label_key2": "label_value2"
 						}
 					  }
 					}
@@ -380,6 +403,10 @@ var _ = Describe("Cluster creation", func() {
 						},
 						"compute_machine_type": {
 							"id": "r5.xlarge"
+						},
+						"compute_labels": {
+							"label_key1": "label_value1",
+				    		"label_key2": "label_value2"
 						}
 					  }
 					}
@@ -395,6 +422,10 @@ var _ = Describe("Cluster creation", func() {
 			autoscaling_enabled = "true"
 			min_replicas = "3"
 			max_replicas = "4"
+			compute_labels = {
+				"label_key1" = "label_value1", 
+				"label_key2" = "label_value2"
+			}
 			sts = {
 				role_arn = "arn:aws:iam::account-id:role/ManagedOpenShift-Installer-Role",
 				support_role_arn = "arn:aws:iam::account-id:role/ManagedOpenShift-Support-Role",
@@ -441,6 +472,10 @@ var _ = Describe("Cluster creation", func() {
 						},
 						"compute_machine_type": {
 							"id": "r5.xlarge"
+						},
+						"compute_labels": {
+							"label_key1": "label_value1",
+				    		"label_key2": "label_value2"
 						}
 					  }
 					}
@@ -474,6 +509,10 @@ var _ = Describe("Cluster creation", func() {
 						"compute": 4,
 						"compute_machine_type": {
 							"id": "r5.xlarge"
+						},
+						"compute_labels": {
+							"label_key1": "label_value1",
+				    		"label_key2": "label_value2"
 						}
 					  }
 					}
@@ -487,6 +526,10 @@ var _ = Describe("Cluster creation", func() {
 			cloud_region   = "us-west-1"
 			aws_account_id = "123" 
 			replicas = 4
+			compute_labels = {
+				"label_key1" = "label_value1", 
+				"label_key2" = "label_value2"
+			}
 			sts = {
 				role_arn = "arn:aws:iam::account-id:role/ManagedOpenShift-Installer-Role",
 				support_role_arn = "arn:aws:iam::account-id:role/ManagedOpenShift-Support-Role",

--- a/subsystem/machine_pool_resource_test.go
+++ b/subsystem/machine_pool_resource_test.go
@@ -54,12 +54,27 @@ var _ = Describe("Machine pool creation", func() {
 				  "kind": "MachinePool",
 				  "id": "my-pool",
 				  "instance_type": "r5.xlarge",
-				  "replicas": 10
+				  "labels": {
+				    "label_key1": "label_value1",
+				    "label_key2": "label_value2"
+				  },
+				  "replicas": 10,
+				  "taints": [
+					  {
+						"effect": "effect1",
+						"key": "key1",
+						"value": "value1"
+					  }
+				 ]
 				}`),
 				RespondWithJSON(http.StatusOK, `{
 				  "id": "my-pool",
 				  "instance_type": "r5.xlarge",
-				  "replicas": 10
+				  "replicas": 10,
+				  "labels": {
+				    "label_key1": "label_value1",
+				    "label_key2": "label_value2"
+				  }
 				}`),
 			),
 		)
@@ -71,6 +86,17 @@ var _ = Describe("Machine pool creation", func() {
 		    name         = "my-pool"
 		    machine_type = "r5.xlarge"
 		    replicas     = 10
+			labels = {
+				"label_key1" = "label_value1", 
+				"label_key2" = "label_value2"
+			}
+			taints = [
+				{
+					key = "key1",
+					value = "value1",
+					schedule_type = "effect1",
+				},
+		    ]
 		  }
 		`)
 		Expect(terraform.Apply()).To(BeZero())
@@ -82,6 +108,7 @@ var _ = Describe("Machine pool creation", func() {
 		Expect(resource).To(MatchJQ(".attributes.name", "my-pool"))
 		Expect(resource).To(MatchJQ(".attributes.machine_type", "r5.xlarge"))
 		Expect(resource).To(MatchJQ(".attributes.replicas", 10.0))
+		Expect(resource).To(MatchJQ(`.attributes.labels | length`, 2))
 	})
 
 	It("Can create machine pool with autoscaling enabled and update to compute nodes", func() {

--- a/subsystem/main_test.go
+++ b/subsystem/main_test.go
@@ -33,22 +33,23 @@ import (
 	. "github.com/openshift-online/ocm-sdk-go/testing" // nolint
 )
 
-func TestProvider(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Provider")
-}
-
 // All tests will use this API server and Terraform runner:
 var (
 	server    *Server
 	terraform *TerraformRunner
+	testingT  *testing.T
 )
+
+func TestProvider(t *testing.T) {
+	RegisterFailHandler(Fail)
+	testingT = t
+	RunSpecs(t, "Provider")
+}
 
 var _ = BeforeEach(func() {
 	// Create the server:
 	var ca string
 	server, ca = MakeTCPTLSServer()
-
 	// Create an access token:
 	token := MakeTokenString("Bearer", 10*time.Minute)
 

--- a/subsystem/rosa_operator_roles_data_source_test.go
+++ b/subsystem/rosa_operator_roles_data_source_test.go
@@ -14,8 +14,8 @@ const (
 	// This is the cluster that will be returned by the server when asked to retrieve a cluster with ID 123
 	getStsCredentialRequests = `{
 	"page": 1,
-	"size": 6,
-	"total": 6,
+	"size": 2,
+	"total": 2,
 	"items": [
 		{
 			"kind": "STSOperator",
@@ -74,7 +74,16 @@ var _ = Describe("ROSA Operator IAM roles data source", func() {
 		Expect(resource).To(MatchJQ(`.attributes.operator_role_prefix`, "terraform-operator"))
 		Expect(resource).To(MatchJQ(`.attributes.account_role_prefix`, "TerraformAccountPrefix"))
 		Expect(resource).To(MatchJQ(`.attributes.operator_iam_roles | length`, 2))
-		compareResultOfRoles(resource, 1,
+
+		index := 0
+		firstOperatorName := resource.(map[string]interface{})["attributes"].(map[string]interface{})["operator_iam_roles"].([]interface{})[0].(map[string]interface{})["operator_name"].(string)
+		testingT.Log("firstOperatorName = ", firstOperatorName)
+		if firstOperatorName != "ebs-cloud-credentials" {
+			index = 1
+		}
+		testingT.Log("index = ", index)
+
+		compareResultOfRoles(resource, index,
 			"ebs-cloud-credentials",
 			"openshift-cluster-csi-drivers",
 			"TerraformAccountPrefix-openshift-cluster-csi-drivers-ebs-cloud-c",
@@ -86,7 +95,7 @@ var _ = Describe("ROSA Operator IAM roles data source", func() {
 			},
 		)
 
-		compareResultOfRoles(resource, 0,
+		compareResultOfRoles(resource, 1-index,
 			"cloud-credentials",
 			"openshift-cloud-network-config-controller",
 			"TerraformAccountPrefix-openshift-cloud-network-config-controller",
@@ -118,7 +127,17 @@ var _ = Describe("ROSA Operator IAM roles data source", func() {
 		//Expect(resource).To(MatchJQ(`.attributes.items | length`, 1))
 		Expect(resource).To(MatchJQ(`.attributes.operator_role_prefix`, "terraform-operator"))
 		Expect(resource).To(MatchJQ(`.attributes.operator_iam_roles | length`, 2))
-		compareResultOfRoles(resource, 1,
+
+		index := 0
+		firstOperatorName := resource.(map[string]interface{})["attributes"].(map[string]interface{})["operator_iam_roles"].([]interface{})[0].(map[string]interface{})["operator_name"].(string)
+		testingT.Log("*firstOperatorName = ", firstOperatorName)
+		if firstOperatorName != "ebs-cloud-credentials" {
+			index = 1
+		}
+
+		testingT.Log("index = ", index)
+
+		compareResultOfRoles(resource, index,
 			"ebs-cloud-credentials",
 			"openshift-cluster-csi-drivers",
 			"ManagedOpenShift-openshift-cluster-csi-drivers-ebs-cloud-credent",
@@ -130,7 +149,7 @@ var _ = Describe("ROSA Operator IAM roles data source", func() {
 			},
 		)
 
-		compareResultOfRoles(resource, 0,
+		compareResultOfRoles(resource, 1-index,
 			"cloud-credentials",
 			"openshift-cloud-network-config-controller",
 			"ManagedOpenShift-openshift-cloud-network-config-controller-cloud",


### PR DESCRIPTION
The changes in this PR are: 
* Support trustBundle string in creating a cluster in rosa sts resource 
* Support adding labels and taints in machine pool resource
* Fix a flakiness index order in ROSA Operator IAM roles data source
* Support adding computeLabels for the default machine pool in rosa sts cluster resource
