### PR TITLE
Address cluster state

### DIFF
--- a/docs/resources/cluster_rosa_classic.md
+++ b/docs/resources/cluster_rosa_classic.md
@@ -27,6 +27,7 @@ OpenShift managed cluster using rosa sts.
 - `availability_zones` (List of String) availability zones
 - `aws_private_link` (Boolean) aws subnet ids
 - `aws_subnet_ids` (List of String) aws subnet ids
+- `compute_labels` (Map of String) Labels for the default machine pool. Format should be a comma-separated list of 'key=value'. This list will overwrite any modifications made to Node labels on an ongoing basis.
 - `compute_machine_type` (String) Identifier of the machine type used by the compute nodes, for example `r5.xlarge`. Use the `ocm_machine_types` data source to find the possible values.
 - `disable_scp_checks` (Boolean) Enables you to monitor your own projects in isolation from Red Hat Site Reliability Engineer (SRE) platform metrics.
 - `disable_workload_monitoring` (Boolean) Enables you to monitor your own projects in isolation from Red Hat Site Reliability Engineer (SRE) platform metrics.
@@ -47,6 +48,7 @@ OpenShift managed cluster using rosa sts.
 - `sts` (Attributes) STS Configuration (see [below for nested schema](#nestedatt--sts))
 - `tags` (Map of String) Apply user defined tags to all resources created in AWS.
 - `version` (String) Identifier of the version of OpenShift, for example 'openshift-v4.1.0'.
+- `wait_with_timeout` (Number) Wait with a timeout till the cluster is ready. The timeout value should be in minutes
 
 ### Read-Only
 
@@ -66,6 +68,7 @@ Required:
 
 Optional:
 
+- `additional_trust_bundle` (String) a string contains contains a PEM-encoded X.509 certificate bundle that will be added to the nodes' trusted certificate store.
 - `no_proxy` (String) no proxy
 
 

--- a/docs/resources/machine_pool.md
+++ b/docs/resources/machine_pool.md
@@ -24,12 +24,23 @@ Machine pool.
 ### Optional
 
 - `autoscaling_enabled` (Boolean) Enables autoscaling.
+- `labels` (Map of String) Labels for machine pool. Format should be a comma-separated list of 'key = value'. This list will overwrite any modifications made to node labels on an ongoing basis..
 - `max_replicas` (Number) Max replicas.
 - `min_replicas` (Number) Min replicas.
 - `replicas` (Number) The number of machines of the pool
+- `taints` (Attributes List) Taints for machine pool. Format should be a comma-separated list of 'key=value:ScheduleType'. This list will overwrite any modifications made to node taints on an ongoing basis. (see [below for nested schema](#nestedatt--taints))
 
 ### Read-Only
 
 - `id` (String) Unique identifier of the machine pool.
+
+<a id="nestedatt--taints"></a>
+### Nested Schema for `taints`
+
+Required:
+
+- `key` (String) Taints key
+- `schedule_type` (String) Taints schedule type
+- `value` (String) Taints value
 
 

--- a/provider/cluster_rosa_classic_resource.go
+++ b/provider/cluster_rosa_classic_resource.go
@@ -45,6 +45,7 @@ const (
 	MinVersion                = "4.10"
 	nonPositiveTimeoutSummary = "Can't poll cluster state with a non-positive timeout"
 	nonPositiveTimeoutFormat  = "Can't poll state of cluster with identifier '%s', the timeout that was set is not a positive number"
+	pollingIntervalInMinutes  = 1
 )
 
 var kmsArnRE = regexp.MustCompile(
@@ -671,7 +672,7 @@ func (r *ClusterRosaClassicResource) waitForClusterStateWithTimeout(ctx context.
 	pollCtx, cancel := context.WithTimeout(ctx, timeoutInMinutes)
 	defer cancel()
 	_, err := r.collection.Cluster(object.ID()).Poll().
-		Interval(1 * time.Minute).
+		Interval(pollingIntervalInMinutes * time.Minute).
 		Predicate(func(getClusterResponse *cmv1.ClusterGetResponse) bool {
 			object = getClusterResponse.Body()
 			logger.Debug(ctx, "cluster state is %s", object.State())
@@ -891,7 +892,7 @@ func (r *ClusterRosaClassicResource) waitTillClusterIsNotFoundWithTimeout(ctx co
 	pollCtx, cancel := context.WithTimeout(ctx, timeoutInMinutes)
 	defer cancel()
 	_, err := resource.Poll().
-		Interval(1 * time.Minute).
+		Interval(pollingIntervalInMinutes * time.Minute).
 		Status(http.StatusNotFound).
 		StartContext(pollCtx)
 	sdkErr, ok := err.(*ocm_errors.Error)

--- a/provider/cluster_rosa_classic_resource.go
+++ b/provider/cluster_rosa_classic_resource.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 
 	semver "github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -34,13 +35,16 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	ocm_errors "github.com/openshift-online/ocm-sdk-go/errors"
 	"github.com/openshift-online/ocm-sdk-go/logging"
 )
 
 const (
-	awsCloudProvider = "aws"
-	rosaProduct      = "rosa"
-	MinVersion       = "4.10"
+	awsCloudProvider          = "aws"
+	rosaProduct               = "rosa"
+	MinVersion                = "4.10"
+	nonPositiveTimeoutSummary = "Can't poll cluster state with a non-positive timeout"
+	nonPositiveTimeoutFormat  = "Can't poll state of cluster with identifier '%s', the timeout that was set is not a positive number"
 )
 
 var kmsArnRE = regexp.MustCompile(
@@ -338,6 +342,11 @@ func (t *ClusterRosaClassicResourceType) GetSchema(ctx context.Context) (result 
 				Type:        types.StringType,
 				Computed:    true,
 			},
+			"wait_with_timeout": {
+				Description: "Wait with a timeout till the cluster is ready. The timeout value should be in minutes",
+				Type:        types.Int64Type,
+				Optional:    true,
+			},
 		},
 	}
 	return
@@ -616,10 +625,65 @@ func (r *ClusterRosaClassicResource) Create(ctx context.Context,
 	}
 	object = add.Body()
 
+	// Wait till the cluster is ready unless explicitly disabled:
+	if !state.WaitWithTimeout.Unknown && !state.WaitWithTimeout.Null {
+		if state.WaitWithTimeout.Value <= 0 {
+			response.Diagnostics.AddWarning(nonPositiveTimeoutSummary, fmt.Sprintf(nonPositiveTimeoutFormat, state.ID.Value))
+		} else {
+			object, err = r.waitForClusterStateWithTimeout(ctx, state.WaitWithTimeout.Value, object, r.logger, cmv1.ClusterStateReady)
+			if err != nil {
+				response.Diagnostics.AddError(
+					"Can't poll cluster state",
+					fmt.Sprintf("Can't poll state of cluster with identifier '%s': %v", object.ID(), err),
+				)
+				return
+			}
+
+			if object.State() != cmv1.ClusterStateReady {
+				response.Diagnostics.AddWarning(
+					"Cluster state is not ready",
+					fmt.Sprintf("The cluster with identifier '%s' is not ready yet, but the polling finisehd due to a timeout", object.ID()),
+				)
+			}
+
+			r.logger.Info(ctx, "Cluster state is %s", object.State())
+		}
+	}
+
 	// Save the state:
-	populateRosaClassicClusterState(ctx, object, state, r.logger, DefaultHttpClient{})
+	err = populateRosaClassicClusterState(ctx, object, state, r.logger, DefaultHttpClient{})
+	if err != nil {
+		response.Diagnostics.AddError(
+			"Can't populate cluster state",
+			fmt.Sprintf(
+				"Received error %v", err,
+			),
+		)
+		return
+	}
 	diags = response.State.Set(ctx, state)
 	response.Diagnostics.Append(diags...)
+}
+
+func (r *ClusterRosaClassicResource) waitForClusterStateWithTimeout(ctx context.Context, WaitWithTimeout int64,
+	object *cmv1.Cluster, logger logging.Logger, requiredState cmv1.ClusterState) (*cmv1.Cluster, error) {
+	timeoutInMinutes := time.Duration(WaitWithTimeout) * time.Minute
+	pollCtx, cancel := context.WithTimeout(ctx, timeoutInMinutes)
+	defer cancel()
+	_, err := r.collection.Cluster(object.ID()).Poll().
+		Interval(1 * time.Minute).
+		Predicate(func(getClusterResponse *cmv1.ClusterGetResponse) bool {
+			object = getClusterResponse.Body()
+			logger.Debug(ctx, "cluster state is %s", object.State())
+			return object.State() == requiredState
+		}).
+		StartContext(pollCtx)
+	if err != nil {
+		logger.Error(ctx, "Can't  poll cluster state")
+		return nil, err
+	}
+
+	return object, nil
 }
 
 func (r *ClusterRosaClassicResource) Read(ctx context.Context, request tfsdk.ReadResourceRequest,
@@ -647,7 +711,16 @@ func (r *ClusterRosaClassicResource) Read(ctx context.Context, request tfsdk.Rea
 	object := get.Body()
 
 	// Save the state:
-	populateRosaClassicClusterState(ctx, object, state, r.logger, DefaultHttpClient{})
+	err = populateRosaClassicClusterState(ctx, object, state, r.logger, DefaultHttpClient{})
+	if err != nil {
+		response.Diagnostics.AddError(
+			"Can't populate cluster state",
+			fmt.Sprintf(
+				"Received error %v", err,
+			),
+		)
+		return
+	}
 	diags = response.State.Set(ctx, state)
 	response.Diagnostics.Append(diags...)
 }
@@ -744,7 +817,16 @@ func (r *ClusterRosaClassicResource) Update(ctx context.Context, request tfsdk.U
 	object := update.Body()
 
 	// Update the state:
-	populateRosaClassicClusterState(ctx, object, state, r.logger, DefaultHttpClient{})
+	err = populateRosaClassicClusterState(ctx, object, state, r.logger, DefaultHttpClient{})
+	if err != nil {
+		response.Diagnostics.AddError(
+			"Can't populate cluster state",
+			fmt.Sprintf(
+				"Received error %v", err,
+			),
+		)
+		return
+	}
 	diags = response.State.Set(ctx, state)
 	response.Diagnostics.Append(diags...)
 }
@@ -773,8 +855,56 @@ func (r *ClusterRosaClassicResource) Delete(ctx context.Context, request tfsdk.D
 		return
 	}
 
+	// Wait till the cluster has been effectively deleted:
+	if !state.WaitWithTimeout.Unknown && !state.WaitWithTimeout.Null {
+		if state.WaitWithTimeout.Value <= 0 {
+			response.Diagnostics.AddWarning(nonPositiveTimeoutSummary, fmt.Sprintf(nonPositiveTimeoutFormat, state.ID.Value))
+		} else {
+			isNotFound, err := r.waitTillClusterIsNotFoundWithTimeout(ctx, state.WaitWithTimeout.Value, resource, r.logger)
+			if err != nil {
+				response.Diagnostics.AddError(
+					"Can't poll cluster state",
+					fmt.Sprintf(
+						"Can't poll state of cluster with identifier '%s': %v",
+						state.ID.Value, err,
+					),
+				)
+				return
+			}
+
+			if !isNotFound {
+				response.Diagnostics.AddWarning(
+					"Cluster wasn't deleted yet",
+					fmt.Sprintf("The cluster with identifier '%s' is not deleted yet, but the polling finisehd due to a timeout", state.ID.Value),
+				)
+			}
+		}
+	}
+
 	// Remove the state:
 	response.State.RemoveResource(ctx)
+}
+
+func (r *ClusterRosaClassicResource) waitTillClusterIsNotFoundWithTimeout(ctx context.Context, WaitWithTimeout int64,
+	resource *cmv1.ClusterClient, logger logging.Logger) (bool, error) {
+	timeoutInMinutes := time.Duration(WaitWithTimeout) * time.Minute
+	pollCtx, cancel := context.WithTimeout(ctx, timeoutInMinutes)
+	defer cancel()
+	_, err := resource.Poll().
+		Interval(1 * time.Minute).
+		Status(http.StatusNotFound).
+		StartContext(pollCtx)
+	sdkErr, ok := err.(*ocm_errors.Error)
+	if ok && sdkErr.Status() == http.StatusNotFound {
+		logger.Info(ctx, "Cluster was removed")
+		return true, nil
+	}
+	if err != nil {
+		logger.Error(ctx, "Can't poll cluster deletion")
+		return false, err
+	}
+
+	return false, nil
 }
 
 func (r *ClusterRosaClassicResource) ImportState(ctx context.Context, request tfsdk.ImportResourceStateRequest,

--- a/provider/cluster_rosa_classic_state.go
+++ b/provider/cluster_rosa_classic_state.go
@@ -54,6 +54,7 @@ type ClusterRosaClassicState struct {
 	Proxy                     *Proxy       `tfsdk:"proxy"`
 	State                     types.String `tfsdk:"state"`
 	Version                   types.String `tfsdk:"version"`
+	WaitWithTimeout           types.Int64  `tfsdk:"wait_with_timeout"`
 }
 
 type Sts struct {

--- a/subsystem/main_test.go
+++ b/subsystem/main_test.go
@@ -236,6 +236,11 @@ func (r *TerraformRunner) Apply() int {
 	return r.Run("apply", "-auto-approve")
 }
 
+// Destroy runs the `destroy` command.
+func (r *TerraformRunner) Destroy() int {
+	return r.Run("destroy", "-auto-approve")
+}
+
 // State returns the reads the Terraform state and returns the result of parsing
 // it as a JSON document.
 func (r *TerraformRunner) State() interface{} {


### PR DESCRIPTION
In this PR I added the ability to track cluster state in ocm_cluster_rosa_classic resource - in create and destroy, by polling the cluster state. 
The user can set a new attribute called `wait_with_timeout` (in minutes) and the Create and Destroy method waits for cluster state in that same timeout. 
