### PR TITLE
Add domain attribute to cluster_rosa_classic resource

### DIFF
--- a/provider/cluster_rosa_classic_resource.go
+++ b/provider/cluster_rosa_classic_resource.go
@@ -180,6 +180,11 @@ func (t *ClusterRosaClassicResourceType) GetSchema(ctx context.Context) (result 
 				Type:        types.StringType,
 				Computed:    true,
 			},
+			"domain": {
+				Description: "DNS Domain of Cluster",
+				Type:        types.StringType,
+				Computed:    true,
+			},
 			"replicas": {
 				Description: "Number of worker nodes to provision. Single zone clusters need at least 2 nodes, " +
 					"multizone clusters need at least 3 nodes.",
@@ -942,6 +947,9 @@ func populateRosaClassicClusterState(ctx context.Context, object *cmv1.Cluster, 
 	}
 	state.ConsoleURL = types.String{
 		Value: object.Console().URL(),
+	}
+	state.Domain = types.String{
+		Value: fmt.Sprintf("%s.%s", object.Name(), object.DNS().BaseDomain()),
 	}
 	state.Replicas = types.Int64{
 		Value: int64(object.Nodes().Compute()),

--- a/provider/cluster_rosa_classic_resource_test.go
+++ b/provider/cluster_rosa_classic_resource_test.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -48,6 +49,7 @@ const (
 	rosaCreatorArn    = "arn:aws:iam::123456789012:dummy/dummy"
 	apiUrl            = "https://api.my-cluster.com:6443"
 	consoleUrl        = "https://console.my-cluster.com"
+	baseDomain        = "alias.p1.openshiftapps.com"
 	machineType       = "m5.xlarge"
 	availabilityZone1 = "us-east-1a"
 	availabilityZone2 = "us-east-1b"
@@ -76,7 +78,8 @@ var (
 
 func generateBasicRosaClassicClusterJson() map[string]interface{} {
 	return map[string]interface{}{
-		"id": clusterId,
+		"id":   clusterId,
+		"name": clusterName,
 		"region": map[string]interface{}{
 			"id": regionId,
 		},
@@ -89,6 +92,9 @@ func generateBasicRosaClassicClusterJson() map[string]interface{} {
 		},
 		"console": map[string]interface{}{
 			"url": consoleUrl,
+		},
+		"dns": map[string]interface{}{
+			"base_domain": baseDomain,
 		},
 		"nodes": map[string]interface{}{
 			"compute_machine_type": map[string]interface{}{
@@ -216,6 +222,7 @@ var _ = Describe("Rosa Classic Sts cluster", func() {
 			Expect(clusterState.Properties.Elems["rosa_creator_arn"].Equal(types.String{Value: rosaCreatorArn})).To(Equal(true))
 			Expect(clusterState.APIURL.Value).To(Equal(apiUrl))
 			Expect(clusterState.ConsoleURL.Value).To(Equal(consoleUrl))
+			Expect(clusterState.Domain.Value).To(Equal(fmt.Sprintf("%s.%s", clusterName, baseDomain)))
 			Expect(clusterState.ComputeMachineType.Value).To(Equal(machineType))
 			Expect(clusterState.AvailabilityZones.Elems).To(HaveLen(1))
 			Expect(clusterState.AvailabilityZones.Elems[0].Equal(types.String{Value: availabilityZone1})).To(Equal(true))

--- a/provider/cluster_rosa_classic_state.go
+++ b/provider/cluster_rosa_classic_state.go
@@ -36,6 +36,7 @@ type ClusterRosaClassicState struct {
 	ComputeLabels             types.Map    `tfsdk:"compute_labels"`
 	Replicas                  types.Int64  `tfsdk:"replicas"`
 	ConsoleURL                types.String `tfsdk:"console_url"`
+	Domain                    types.String `tfsdk:"domain"`
 	HostPrefix                types.Int64  `tfsdk:"host_prefix"`
 	ID                        types.String `tfsdk:"id"`
 	FIPS                      types.Bool   `tfsdk:"fips"`


### PR DESCRIPTION
The `dns.base_domain` attribute is immediately available from the API when creating a new cluster, and can be useful in further configuration of resources within the same terraform run.

This value can be queried using `rosa describe cluster -c id`. The value from the ROSA CLI is always `[name].[dns.base_domain]`, which is why the domain attribute prepends the cluster name in this proposed feature.

An example use would be configuring an OpenID IdP using the domain attribute for the callback URL.

This creates a nice workflow where the cluster creation can begin in the background (required already because of the OIDC Provider dependency), and the `ocm_identity_provider` of type OpenID can be created in the same terraform run, which will trigger the wait for cluster install completion loop on `ocm_identity_provider`.

The result is a single terraform run for a ROSA cluster build, that does not exit until the cluster is ready for use, with SSO login enabled.