### PR TITLE
OCM-174: Added GitHub IDP provider attrs

### DIFF
--- a/docs/resources/identity_provider.md
+++ b/docs/resources/identity_provider.md
@@ -22,6 +22,7 @@ Identity provider.
 
 ### Optional
 
+- `github` (Attributes) Details of the Github identity provider. (see [below for nested schema](#nestedatt--github))
 - `gitlab` (Attributes) Details of the Gitlab identity provider. (see [below for nested schema](#nestedatt--gitlab))
 - `htpasswd` (Attributes) Details of the 'htpasswd' identity provider. (see [below for nested schema](#nestedatt--htpasswd))
 - `ldap` (Attributes) Details of the LDAP identity provider. (see [below for nested schema](#nestedatt--ldap))
@@ -30,6 +31,22 @@ Identity provider.
 ### Read-Only
 
 - `id` (String) Unique identifier of the identity provider.
+
+<a id="nestedatt--github"></a>
+### Nested Schema for `github`
+
+Required:
+
+- `client_id` (String) Client identifier of a registered Github OAuth application.
+- `client_secret` (String, Sensitive) Client secret issued by Github.
+
+Optional:
+
+- `ca` (String) Path to PEM-encoded certificate file to use when making requests to the server.
+- `hostname` (String) Optional domain to use with a hosted instance of GitHub Enterprise.
+- `organizations` (List of String) Only users that are members of at least one of the listed organizations will be allowed to log in.
+- `teams` (List of String) Only users that are members of at least one of the listed teams will be allowed to log in. The format is <org>/<team>.
+
 
 <a id="nestedatt--gitlab"></a>
 ### Nested Schema for `gitlab`

--- a/provider/cluster_resource.go
+++ b/provider/cluster_resource.go
@@ -29,6 +29,7 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 	"github.com/openshift-online/ocm-sdk-go/logging"
+	"github.com/terraform-redhat/terraform-provider-ocm/provider/common"
 )
 
 type ClusterResourceType struct {
@@ -470,7 +471,7 @@ func (r *ClusterResource) Update(ctx context.Context, request tfsdk.UpdateResour
 	// Send request to update the cluster:
 	builder := cmv1.NewCluster()
 	var nodes *cmv1.ClusterNodesBuilder
-	compute, ok := shouldPatchInt(state.ComputeNodes, plan.ComputeNodes)
+	compute, ok := common.ShouldPatchInt(state.ComputeNodes, plan.ComputeNodes)
 	if ok {
 		nodes.Compute(int(compute))
 	}

--- a/provider/cluster_rosa_classic_resource.go
+++ b/provider/cluster_rosa_classic_resource.go
@@ -33,6 +33,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/terraform-redhat/terraform-provider-ocm/provider/common"
 
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -972,7 +973,7 @@ func (r *ClusterRosaClassicResource) Update(ctx context.Context, request tfsdk.U
 	updateNodes := false
 	clusterBuilder := cmv1.NewCluster()
 	clusterNodesBuilder := cmv1.NewClusterNodes()
-	compute, ok := shouldPatchInt(state.Replicas, plan.Replicas)
+	compute, ok := common.ShouldPatchInt(state.Replicas, plan.Replicas)
 	if ok {
 		clusterNodesBuilder = clusterNodesBuilder.Compute(int(compute))
 		updateNodes = true

--- a/provider/common/attribute_validator.go
+++ b/provider/common/attribute_validator.go
@@ -1,0 +1,24 @@
+package common
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+)
+
+type AttributeValidator struct {
+	Desc      string
+	MDDesc    string
+	Validator func(ctx context.Context, req tfsdk.ValidateAttributeRequest, resp *tfsdk.ValidateAttributeResponse)
+}
+
+var _ tfsdk.AttributeValidator = &AttributeValidator{}
+
+func (a *AttributeValidator) Description(context.Context) string {
+	return a.Desc
+}
+func (a *AttributeValidator) MarkdownDescription(context.Context) string {
+	return a.MDDesc
+}
+func (a *AttributeValidator) Validate(ctx context.Context, req tfsdk.ValidateAttributeRequest, resp *tfsdk.ValidateAttributeResponse) {
+	a.Validator(ctx, req, resp)
+}

--- a/provider/common/helpers.go
+++ b/provider/common/helpers.go
@@ -14,15 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package provider
+package common
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/pkg/errors"
 )
 
 // shouldPatchInt changed checks if the change between the given state and plan requires sending a
 // patch request to the server. If it does it returns the value to add to the patch.
-func shouldPatchInt(state, plan types.Int64) (value int64, ok bool) {
+func ShouldPatchInt(state, plan types.Int64) (value int64, ok bool) {
 	if plan.Unknown || plan.Null {
 		return
 	}
@@ -40,7 +42,7 @@ func shouldPatchInt(state, plan types.Int64) (value int64, ok bool) {
 
 // shouldPatchString changed checks if the change between the given state and plan requires sending
 // a patch request to the server. If it does it returns the value to add to the patch.
-func shouldPatchString(state, plan types.String) (value string, ok bool) {
+func ShouldPatchString(state, plan types.String) (value string, ok bool) {
 	if plan.Unknown || plan.Null {
 		return
 	}
@@ -54,4 +56,30 @@ func shouldPatchString(state, plan types.String) (value string, ok bool) {
 		ok = true
 	}
 	return
+}
+
+// TF types converter functions
+func StringArrayToList(arr []string) types.List {
+	list := types.List{
+		ElemType: types.StringType,
+		Elems:    []attr.Value{},
+	}
+
+	for _, elm := range arr {
+		list.Elems = append(list.Elems, types.String{Value: elm})
+	}
+
+	return list
+}
+
+func StringListToArray(list types.List) ([]string, error) {
+	arr := []string{}
+	for _, elm := range list.Elems {
+		stype, ok := elm.(types.String)
+		if !ok {
+			return arr, errors.New("Failed to convert TF list to string slice.")
+		}
+		arr = append(arr, stype.Value)
+	}
+	return arr, nil
 }

--- a/provider/identity_provider_state.go
+++ b/provider/identity_provider_state.go
@@ -18,16 +18,18 @@ package provider
 
 import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/terraform-redhat/terraform-provider-ocm/provider/idps"
 )
 
 type IdentityProviderState struct {
-	Cluster  types.String              `tfsdk:"cluster"`
-	ID       types.String              `tfsdk:"id"`
-	Name     types.String              `tfsdk:"name"`
-	HTPasswd *HTPasswdIdentityProvider `tfsdk:"htpasswd"`
-	Gitlab   *GitlabIdentityProvider   `tfsdk:"gitlab"`
-	LDAP     *LDAPIdentityProvider     `tfsdk:"ldap"`
-	OpenID   *OpenIDIdentityProvider   `tfsdk:"openid"`
+	Cluster  types.String                 `tfsdk:"cluster"`
+	ID       types.String                 `tfsdk:"id"`
+	Name     types.String                 `tfsdk:"name"`
+	HTPasswd *HTPasswdIdentityProvider    `tfsdk:"htpasswd"`
+	Gitlab   *GitlabIdentityProvider      `tfsdk:"gitlab"`
+	Github   *idps.GithubIdentityProvider `tfsdk:"github"`
+	LDAP     *LDAPIdentityProvider        `tfsdk:"ldap"`
+	OpenID   *OpenIDIdentityProvider      `tfsdk:"openid"`
 }
 
 type HTPasswdIdentityProvider struct {

--- a/provider/idps/github.go
+++ b/provider/idps/github.go
@@ -1,0 +1,168 @@
+package idps
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
+	"github.com/terraform-redhat/terraform-provider-ocm/provider/common"
+)
+
+type GithubIdentityProvider struct {
+	CA            types.String `tfsdk:"ca"`
+	ClientID      types.String `tfsdk:"client_id"`
+	ClientSecret  types.String `tfsdk:"client_secret"`
+	Hostname      types.String `tfsdk:"hostname"`
+	Organizations types.List   `tfsdk:"organizations"`
+	Teams         types.List   `tfsdk:"teams"`
+}
+
+func GithubSchema() tfsdk.NestedAttributes {
+	return tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
+		"client_id": {
+			Description: "Client identifier of a registered Github OAuth application.",
+			Type:        types.StringType,
+			Required:    true,
+		},
+		"client_secret": {
+			Description: "Client secret issued by Github.",
+			Type:        types.StringType,
+			Required:    true,
+			Sensitive:   true,
+		},
+		"ca": {
+			Description: "Path to PEM-encoded certificate file to use when making requests to the server.",
+			Type:        types.StringType,
+			Optional:    true,
+		},
+		"hostname": {
+			Description: "Optional domain to use with a hosted instance of GitHub Enterprise.",
+			Type:        types.StringType,
+			Optional:    true,
+		},
+		"organizations": {
+			Description: "Only users that are members of at least one of the listed organizations will be allowed to log in.",
+			Type: types.ListType{
+				ElemType: types.StringType,
+			},
+			Optional: true,
+		},
+		"teams": {
+			Description: "Only users that are members of at least one of the listed teams will be allowed to log in. The format is <org>/<team>.",
+			Type: types.ListType{
+				ElemType: types.StringType,
+			},
+			Optional: true,
+		},
+	})
+}
+
+func GithubValidators() []tfsdk.AttributeValidator {
+	errSumm := "Invalid GitHub IDP resource configuration"
+	return []tfsdk.AttributeValidator{
+		&common.AttributeValidator{
+			Desc:   "GitHub IDP requires either organizations or teams",
+			MDDesc: "",
+			Validator: func(ctx context.Context, req tfsdk.ValidateAttributeRequest, resp *tfsdk.ValidateAttributeResponse) {
+				ghState := &GithubIdentityProvider{}
+				diag := req.Config.GetAttribute(ctx, req.AttributePath, ghState)
+				if diag.HasError() {
+					// No attribute to validate
+					return
+				}
+				// At only one restriction plan is required
+				areTeamsDefined := !ghState.Teams.Unknown && !ghState.Teams.Null
+				areOrgsDefined := !ghState.Organizations.Unknown && !ghState.Organizations.Null
+				if !areOrgsDefined && !areTeamsDefined {
+					resp.Diagnostics.AddError(errSumm, "GitHub IDP requires missing attributes 'organizations' OR 'teams'")
+				}
+				if areOrgsDefined && areTeamsDefined {
+					resp.Diagnostics.AddError(errSumm, "GitHub IDP requires either 'organizations' or 'teams', not both.")
+				}
+			},
+		},
+		&common.AttributeValidator{
+			Desc:   "GitHub IDP teams format validator",
+			MDDesc: "",
+			Validator: func(ctx context.Context, req tfsdk.ValidateAttributeRequest, resp *tfsdk.ValidateAttributeResponse) {
+				ghState := &GithubIdentityProvider{}
+				diag := req.Config.GetAttribute(ctx, req.AttributePath, ghState)
+				if diag.HasError() {
+					// No attribute to validate
+					return
+				}
+				// Validate teams format
+				teams := []string{}
+				dig := ghState.Teams.ElementsAs(ctx, &teams, false)
+				if dig.HasError() {
+					// Nothing to validate
+					return
+				}
+				for i, team := range teams {
+					parts := strings.Split(team, "/")
+					if len(parts) != 2 {
+						resp.Diagnostics.AddError(errSumm,
+							fmt.Sprintf("Expected a GitHub team to follow the form '<org>/<team>', Got %v at index %d",
+								team, i),
+						)
+						return
+					}
+				}
+			},
+		},
+		&common.AttributeValidator{
+			Desc:   "Github IDP hostname validator",
+			MDDesc: "",
+			Validator: func(ctx context.Context, req tfsdk.ValidateAttributeRequest, resp *tfsdk.ValidateAttributeResponse) {
+				ghState := &GithubIdentityProvider{}
+				diag := req.Config.GetAttribute(ctx, req.AttributePath, ghState)
+				if diag.HasError() {
+					// No attribute to validate
+					return
+				}
+				// Validate hostname
+				if !ghState.Hostname.Unknown && !ghState.Hostname.Null && len(ghState.Hostname.Value) > 0 {
+					_, err := url.ParseRequestURI(ghState.Hostname.Value)
+					if err != nil {
+						resp.Diagnostics.AddError(errSumm,
+							fmt.Sprintf("Expected a valid GitHub hostname. Got %v",
+								ghState.Hostname.Value),
+						)
+					}
+				}
+			},
+		},
+	}
+}
+
+func CreateGithubIDPBuilder(ctx context.Context, ghState *GithubIdentityProvider) (*cmv1.GithubIdentityProviderBuilder, error) {
+	githubBuilder := cmv1.NewGithubIdentityProvider()
+	githubBuilder.ClientID(ghState.ClientID.Value)
+	githubBuilder.ClientSecret(ghState.ClientSecret.Value)
+	if !ghState.CA.Unknown && !ghState.CA.Null {
+		githubBuilder.CA(ghState.CA.Value)
+	}
+	if !ghState.Hostname.Unknown && !ghState.Hostname.Null && len(ghState.Hostname.Value) > 0 {
+		githubBuilder.Hostname(ghState.Hostname.Value)
+	}
+	if !ghState.Teams.Unknown && !ghState.Teams.Null {
+		teams, err := common.StringListToArray(ghState.Teams)
+		if err != nil {
+			return nil, err
+		}
+		githubBuilder.Teams(teams...)
+	}
+	if !ghState.Organizations.Unknown && !ghState.Organizations.Null {
+		orgs, err := common.StringListToArray(ghState.Organizations)
+		if err != nil {
+			return nil, err
+		}
+		githubBuilder.Organizations(orgs...)
+	}
+	return githubBuilder, nil
+}

--- a/provider/machine_pool_resource.go
+++ b/provider/machine_pool_resource.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/terraform-redhat/terraform-provider-ocm/provider/common"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift-online/ocm-sdk-go/logging"
@@ -371,7 +372,7 @@ func (r *MachinePoolResource) Update(ctx context.Context, request tfsdk.UpdateRe
 
 	mpBuilder := cmv1.NewMachinePool().ID(state.ID.Value)
 
-	_, ok := shouldPatchString(state.MachineType, plan.MachineType)
+	_, ok := common.ShouldPatchString(state.MachineType, plan.MachineType)
 	if ok {
 		response.Diagnostics.AddError(
 			"Can't update machine pool",


### PR DESCRIPTION
- Created new `idps` package. In future PRs will move all the providers
to this package.

- Added ability to create a github idp.

- Added an attribute validator helper struct for easy validation
construction.

- Added subsytem tests

Validations are based on ROSA CLI