### PR TITLE
OCM-177: Move all identity providers to internal pkg

### DIFF
--- a/docs/resources/identity_provider.md
+++ b/docs/resources/identity_provider.md
@@ -77,24 +77,24 @@ Required:
 Required:
 
 - `attributes` (Attributes) (see [below for nested schema](#nestedatt--ldap--attributes))
-- `bind_dn` (String)
-- `bind_password` (String, Sensitive)
-- `url` (String)
+- `bind_dn` (String) DN to bind with during the search phase.
+- `bind_password` (String, Sensitive) Password to bind with during the search phase.
+- `url` (String) An RFC 2255 URL which specifies the LDAP search parameters to use.
 
 Optional:
 
-- `ca` (String)
-- `insecure` (Boolean)
+- `ca` (String) Optional trusted certificate authority bundle.
+- `insecure` (Boolean) Do not make TLS connections to the server.
 
 <a id="nestedatt--ldap--attributes"></a>
 ### Nested Schema for `ldap.attributes`
 
 Optional:
 
-- `email` (List of String)
-- `id` (List of String)
-- `name` (List of String)
-- `preferred_username` (List of String)
+- `email` (List of String) The list of attributes whose values should be used as the email address.
+- `id` (List of String) The list of attributes whose values should be used as the user ID. (default 'dn')
+- `name` (List of String) The list of attributes whose values should be used as the display name. (default 'cn')
+- `preferred_username` (List of String) The list of attributes whose values should be used as the preferred username. (default 'uid')
 
 
 
@@ -103,25 +103,25 @@ Optional:
 
 Required:
 
-- `claims` (Attributes) (see [below for nested schema](#nestedatt--openid--claims))
-- `client_id` (String)
-- `client_secret` (String, Sensitive)
-- `issuer` (String)
+- `claims` (Attributes) OpenID Claims config. (see [below for nested schema](#nestedatt--openid--claims))
+- `client_id` (String) Client ID from the registered application.
+- `client_secret` (String, Sensitive) Client Secret from the registered application.
+- `issuer` (String) The URL that the OpenID Provider asserts as the Issuer Identifier. It must use the https scheme with no URL query parameters or fragment.
 
 Optional:
 
-- `ca` (String)
+- `ca` (String) Optional trusted certificate authority bundle.
 - `extra_authorize_parameters` (List of String)
-- `extra_scopes` (List of String)
+- `extra_scopes` (List of String) List of scopes to request, in addition to the 'openid' scope, during the authorization token request.
 
 <a id="nestedatt--openid--claims"></a>
 ### Nested Schema for `openid.claims`
 
 Optional:
 
-- `email` (List of String)
-- `groups` (List of String)
-- `name` (List of String)
-- `preferred_username` (List of String)
+- `email` (List of String) List of claims to use as the email address.
+- `groups` (List of String) List of claims to use as the groups names.
+- `name` (List of String) List of claims to use as the display name.
+- `preferred_username` (List of String) List of claims to use as the preferred username when provisioning a user.
 
 

--- a/provider/identity_provider_state.go
+++ b/provider/identity_provider_state.go
@@ -22,57 +22,12 @@ import (
 )
 
 type IdentityProviderState struct {
-	Cluster  types.String                 `tfsdk:"cluster"`
-	ID       types.String                 `tfsdk:"id"`
-	Name     types.String                 `tfsdk:"name"`
-	HTPasswd *HTPasswdIdentityProvider    `tfsdk:"htpasswd"`
-	Gitlab   *GitlabIdentityProvider      `tfsdk:"gitlab"`
-	Github   *idps.GithubIdentityProvider `tfsdk:"github"`
-	LDAP     *LDAPIdentityProvider        `tfsdk:"ldap"`
-	OpenID   *OpenIDIdentityProvider      `tfsdk:"openid"`
-}
-
-type HTPasswdIdentityProvider struct {
-	Username types.String `tfsdk:"username"`
-	Password types.String `tfsdk:"password"`
-}
-
-type GitlabIdentityProvider struct {
-	CA           types.String `tfsdk:"ca"`
-	ClientID     types.String `tfsdk:"client_id"`
-	ClientSecret types.String `tfsdk:"client_secret"`
-	URL          types.String `tfsdk:"url"`
-}
-
-type LDAPIdentityProvider struct {
-	BindDN       types.String                    `tfsdk:"bind_dn"`
-	BindPassword types.String                    `tfsdk:"bind_password"`
-	CA           types.String                    `tfsdk:"ca"`
-	Insecure     types.Bool                      `tfsdk:"insecure"`
-	URL          types.String                    `tfsdk:"url"`
-	Attributes   *LDAPIdentityProviderAttributes `tfsdk:"attributes"`
-}
-
-type LDAPIdentityProviderAttributes struct {
-	EMail             []string `tfsdk:"email"`
-	ID                []string `tfsdk:"id"`
-	Name              []string `tfsdk:"name"`
-	PreferredUsername []string `tfsdk:"preferred_username"`
-}
-
-type OpenIDIdentityProvider struct {
-	CA                       types.String                  `tfsdk:"ca"`
-	Claims                   *OpenIDIdentityProviderClaims `tfsdk:"claims"`
-	ClientID                 types.String                  `tfsdk:"client_id"`
-	ClientSecret             types.String                  `tfsdk:"client_secret"`
-	ExtraScopes              []string                      `tfsdk:"extra_scopes"`
-	ExtraAuthorizeParameters map[string]string             `tfsdk:"extra_authorize_parameters"`
-	Issuer                   types.String                  `tfsdk:"issuer"`
-}
-
-type OpenIDIdentityProviderClaims struct {
-	EMail             []string `tfsdk:"email"`
-	Groups            []string `tfsdk:"groups"`
-	Name              []string `tfsdk:"name"`
-	PreferredUsername []string `tfsdk:"preferred_username"`
+	Cluster  types.String                   `tfsdk:"cluster"`
+	ID       types.String                   `tfsdk:"id"`
+	Name     types.String                   `tfsdk:"name"`
+	HTPasswd *idps.HTPasswdIdentityProvider `tfsdk:"htpasswd"`
+	Gitlab   *idps.GitlabIdentityProvider   `tfsdk:"gitlab"`
+	Github   *idps.GithubIdentityProvider   `tfsdk:"github"`
+	LDAP     *idps.LDAPIdentityProvider     `tfsdk:"ldap"`
+	OpenID   *idps.OpenIDIdentityProvider   `tfsdk:"openid"`
 }

--- a/provider/idps/github.go
+++ b/provider/idps/github.go
@@ -66,8 +66,7 @@ func GithubValidators() []tfsdk.AttributeValidator {
 	errSumm := "Invalid GitHub IDP resource configuration"
 	return []tfsdk.AttributeValidator{
 		&common.AttributeValidator{
-			Desc:   "GitHub IDP requires either organizations or teams",
-			MDDesc: "",
+			Desc: "GitHub IDP requires either organizations or teams",
 			Validator: func(ctx context.Context, req tfsdk.ValidateAttributeRequest, resp *tfsdk.ValidateAttributeResponse) {
 				ghState := &GithubIdentityProvider{}
 				diag := req.Config.GetAttribute(ctx, req.AttributePath, ghState)
@@ -87,8 +86,7 @@ func GithubValidators() []tfsdk.AttributeValidator {
 			},
 		},
 		&common.AttributeValidator{
-			Desc:   "GitHub IDP teams format validator",
-			MDDesc: "",
+			Desc: "GitHub IDP teams format validator",
 			Validator: func(ctx context.Context, req tfsdk.ValidateAttributeRequest, resp *tfsdk.ValidateAttributeResponse) {
 				ghState := &GithubIdentityProvider{}
 				diag := req.Config.GetAttribute(ctx, req.AttributePath, ghState)
@@ -116,8 +114,7 @@ func GithubValidators() []tfsdk.AttributeValidator {
 			},
 		},
 		&common.AttributeValidator{
-			Desc:   "Github IDP hostname validator",
-			MDDesc: "",
+			Desc: "Github IDP hostname validator",
 			Validator: func(ctx context.Context, req tfsdk.ValidateAttributeRequest, resp *tfsdk.ValidateAttributeResponse) {
 				ghState := &GithubIdentityProvider{}
 				diag := req.Config.GetAttribute(ctx, req.AttributePath, ghState)
@@ -140,25 +137,25 @@ func GithubValidators() []tfsdk.AttributeValidator {
 	}
 }
 
-func CreateGithubIDPBuilder(ctx context.Context, ghState *GithubIdentityProvider) (*cmv1.GithubIdentityProviderBuilder, error) {
+func CreateGithubIDPBuilder(ctx context.Context, state *GithubIdentityProvider) (*cmv1.GithubIdentityProviderBuilder, error) {
 	githubBuilder := cmv1.NewGithubIdentityProvider()
-	githubBuilder.ClientID(ghState.ClientID.Value)
-	githubBuilder.ClientSecret(ghState.ClientSecret.Value)
-	if !ghState.CA.Unknown && !ghState.CA.Null {
-		githubBuilder.CA(ghState.CA.Value)
+	githubBuilder.ClientID(state.ClientID.Value)
+	githubBuilder.ClientSecret(state.ClientSecret.Value)
+	if !state.CA.Unknown && !state.CA.Null {
+		githubBuilder.CA(state.CA.Value)
 	}
-	if !ghState.Hostname.Unknown && !ghState.Hostname.Null && len(ghState.Hostname.Value) > 0 {
-		githubBuilder.Hostname(ghState.Hostname.Value)
+	if !state.Hostname.Unknown && !state.Hostname.Null && len(state.Hostname.Value) > 0 {
+		githubBuilder.Hostname(state.Hostname.Value)
 	}
-	if !ghState.Teams.Unknown && !ghState.Teams.Null {
-		teams, err := common.StringListToArray(ghState.Teams)
+	if !state.Teams.Unknown && !state.Teams.Null {
+		teams, err := common.StringListToArray(state.Teams)
 		if err != nil {
 			return nil, err
 		}
 		githubBuilder.Teams(teams...)
 	}
-	if !ghState.Organizations.Unknown && !ghState.Organizations.Null {
-		orgs, err := common.StringListToArray(ghState.Organizations)
+	if !state.Organizations.Unknown && !state.Organizations.Null {
+		orgs, err := common.StringListToArray(state.Organizations)
 		if err != nil {
 			return nil, err
 		}

--- a/provider/idps/gitlab.go
+++ b/provider/idps/gitlab.go
@@ -1,0 +1,78 @@
+package idps
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
+	"github.com/terraform-redhat/terraform-provider-ocm/provider/common"
+)
+
+type GitlabIdentityProvider struct {
+	CA           types.String `tfsdk:"ca"`
+	ClientID     types.String `tfsdk:"client_id"`
+	ClientSecret types.String `tfsdk:"client_secret"`
+	URL          types.String `tfsdk:"url"`
+}
+
+func GitlabSchema() tfsdk.NestedAttributes {
+	return tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
+		"client_id": {
+			Description: "Client identifier of a registered Gitlab OAuth application.",
+			Type:        types.StringType,
+			Required:    true,
+		},
+		"client_secret": {
+			Description: "Client secret issued by Gitlab.",
+			Type:        types.StringType,
+			Required:    true,
+			Sensitive:   true,
+		},
+		"url": {
+			Description: "URL of the Gitlab instance.",
+			Type:        types.StringType,
+			Required:    true,
+		},
+		"ca": {
+			Description: "Optional trusted certificate authority bundle.",
+			Type:        types.StringType,
+			Optional:    true,
+		},
+	})
+}
+
+func GitlabValidators() []tfsdk.AttributeValidator {
+	errSumm := "Invalid Gitlab IDP resource configuration"
+	return []tfsdk.AttributeValidator{
+		&common.AttributeValidator{
+			Desc: "Validate gitlab 'url'",
+			Validator: func(ctx context.Context, req tfsdk.ValidateAttributeRequest, resp *tfsdk.ValidateAttributeResponse) {
+				state := &GitlabIdentityProvider{}
+				diag := req.Config.GetAttribute(ctx, req.AttributePath, state)
+				if diag.HasError() {
+					// No attribute to validate
+					return
+				}
+				u, err := url.ParseRequestURI(state.URL.Value)
+				if err != nil || u.Scheme != "https" || u.RawQuery != "" || u.Fragment != "" {
+					resp.Diagnostics.AddError(errSumm,
+						"Expected a valid GitLab provider URL: to use an https:// scheme, must not have query parameters and not have a fragment.")
+				}
+			},
+		},
+	}
+}
+
+func CreateGitlabIDPBuilder(ctx context.Context, state *GitlabIdentityProvider) (*cmv1.GitlabIdentityProviderBuilder, error) {
+	gitlabBuilder := cmv1.NewGitlabIdentityProvider()
+	if !state.CA.Unknown && !state.CA.Null {
+		gitlabBuilder.CA(state.CA.Value)
+	}
+	gitlabBuilder.ClientID(state.ClientID.Value)
+	gitlabBuilder.ClientSecret(state.ClientSecret.Value)
+	gitlabBuilder.URL(state.URL.Value)
+	return gitlabBuilder, nil
+}

--- a/provider/idps/htpasswd.go
+++ b/provider/idps/htpasswd.go
@@ -1,0 +1,41 @@
+package idps
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+)
+
+type HTPasswdIdentityProvider struct {
+	Username types.String `tfsdk:"username"`
+	Password types.String `tfsdk:"password"`
+}
+
+func HtpasswdSchema() tfsdk.NestedAttributes {
+	return tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
+		"username": {
+			Description: "User name.",
+			Type:        types.StringType,
+			Required:    true,
+		},
+		"password": {
+			Description: "User password.",
+			Type:        types.StringType,
+			Required:    true,
+			Sensitive:   true,
+		},
+	})
+}
+
+func CreateHTPasswdIDPBuilder(ctx context.Context, state *HTPasswdIdentityProvider) *cmv1.HTPasswdIdentityProviderBuilder {
+	builder := cmv1.NewHTPasswdIdentityProvider()
+	if !state.Username.Null {
+		builder.Username(state.Username.Value)
+	}
+	if !state.Password.Null {
+		builder.Password(state.Password.Value)
+	}
+	return builder
+}

--- a/provider/idps/ldap.go
+++ b/provider/idps/ldap.go
@@ -1,0 +1,148 @@
+package idps
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/terraform-redhat/terraform-provider-ocm/provider/common"
+)
+
+type LDAPIdentityProvider struct {
+	BindDN       types.String                    `tfsdk:"bind_dn"`
+	BindPassword types.String                    `tfsdk:"bind_password"`
+	CA           types.String                    `tfsdk:"ca"`
+	Insecure     types.Bool                      `tfsdk:"insecure"`
+	URL          types.String                    `tfsdk:"url"`
+	Attributes   *LDAPIdentityProviderAttributes `tfsdk:"attributes"`
+}
+
+type LDAPIdentityProviderAttributes struct {
+	EMail             types.List `tfsdk:"email"`
+	ID                types.List `tfsdk:"id"`
+	Name              types.List `tfsdk:"name"`
+	PreferredUsername types.List `tfsdk:"preferred_username"`
+}
+
+func LdapSchema() tfsdk.NestedAttributes {
+	return tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
+		"bind_dn": {
+			Description: "DN to bind with during the search phase.",
+			Type:        types.StringType,
+			Required:    true,
+		},
+		"bind_password": {
+			Description: "Password to bind with during the search phase.",
+			Type:        types.StringType,
+			Required:    true,
+			Sensitive:   true,
+		},
+		"ca": {
+			Description: "Optional trusted certificate authority bundle.",
+			Type:        types.StringType,
+			Optional:    true,
+		},
+		"insecure": {
+			Description: "Do not make TLS connections to the server.",
+			Type:        types.BoolType,
+			Optional:    true,
+			Computed:    true,
+		},
+		"url": {
+			Description: "An RFC 2255 URL which specifies the LDAP search parameters to use.",
+			Type:        types.StringType,
+			Required:    true,
+		},
+		"attributes": {
+			Description: "",
+			Attributes:  ldapAttributesSchema(),
+			Required:    true,
+		},
+	})
+}
+
+func ldapAttributesSchema() tfsdk.NestedAttributes {
+	return tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
+		"email": {
+			Description: "The list of attributes whose values should be used as the email address.",
+			Type: types.ListType{
+				ElemType: types.StringType,
+			},
+			Optional: true,
+		},
+		"id": {
+			Description: "The list of attributes whose values should be used as the user ID. (default 'dn')",
+			Type: types.ListType{
+				ElemType: types.StringType,
+			},
+			Optional: true,
+		},
+		"name": {
+			Description: "The list of attributes whose values should be used as the display name. (default 'cn')",
+			Type: types.ListType{
+				ElemType: types.StringType,
+			},
+			Optional: true,
+		},
+		"preferred_username": {
+			Description: "The list of attributes whose values should be used as the preferred username. (default 'uid')",
+			Type: types.ListType{
+				ElemType: types.StringType,
+			},
+			Optional: true,
+		},
+	})
+}
+
+func CreateLdapIDPBuilder(ctx context.Context, state *LDAPIdentityProvider) (*cmv1.LDAPIdentityProviderBuilder, error) {
+	builder := cmv1.NewLDAPIdentityProvider()
+	if !state.BindDN.Null {
+		builder.BindDN(state.BindDN.Value)
+	}
+	if !state.BindPassword.Null {
+		builder.BindPassword(state.BindPassword.Value)
+	}
+	if !state.CA.Null {
+		builder.CA(state.CA.Value)
+	}
+	if !state.Insecure.Null {
+		builder.Insecure(state.Insecure.Value)
+	}
+	if !state.URL.Null {
+		builder.URL(state.URL.Value)
+	}
+	if state.Attributes != nil {
+		attributesBuilder := cmv1.NewLDAPAttributes()
+		if !state.Attributes.ID.Unknown && !state.Attributes.ID.Null {
+			ids, err := common.StringListToArray(state.Attributes.ID)
+			if err != nil {
+				return nil, err
+			}
+			attributesBuilder.ID(ids...)
+		}
+		if !state.Attributes.EMail.Unknown && !state.Attributes.EMail.Null {
+			emails, err := common.StringListToArray(state.Attributes.EMail)
+			if err != nil {
+				return nil, err
+			}
+			attributesBuilder.Email(emails...)
+		}
+		if !state.Attributes.Name.Unknown && !state.Attributes.Name.Null {
+			names, err := common.StringListToArray(state.Attributes.Name)
+			if err != nil {
+				return nil, err
+			}
+			attributesBuilder.Name(names...)
+		}
+		if !state.Attributes.PreferredUsername.Unknown && !state.Attributes.PreferredUsername.Null {
+			preferredUsernames, err := common.StringListToArray(state.Attributes.PreferredUsername)
+			if err != nil {
+				return nil, err
+			}
+			attributesBuilder.PreferredUsername(preferredUsernames...)
+		}
+		builder.Attributes(attributesBuilder)
+	}
+	return builder, nil
+}

--- a/provider/idps/openid.go
+++ b/provider/idps/openid.go
@@ -1,0 +1,165 @@
+package idps
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/terraform-redhat/terraform-provider-ocm/provider/common"
+)
+
+type OpenIDIdentityProvider struct {
+	CA                       types.String                  `tfsdk:"ca"`
+	Claims                   *OpenIDIdentityProviderClaims `tfsdk:"claims"`
+	ClientID                 types.String                  `tfsdk:"client_id"`
+	ClientSecret             types.String                  `tfsdk:"client_secret"`
+	ExtraScopes              types.List                    `tfsdk:"extra_scopes"`
+	ExtraAuthorizeParameters map[string]string             `tfsdk:"extra_authorize_parameters"`
+	Issuer                   types.String                  `tfsdk:"issuer"`
+}
+
+type OpenIDIdentityProviderClaims struct {
+	EMail             types.List `tfsdk:"email"`
+	Groups            types.List `tfsdk:"groups"`
+	Name              types.List `tfsdk:"name"`
+	PreferredUsername types.List `tfsdk:"preferred_username"`
+}
+
+func OpenidSchema() tfsdk.NestedAttributes {
+	return tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
+		"ca": {
+			Description: "Optional trusted certificate authority bundle.",
+			Type:        types.StringType,
+			Optional:    true,
+		},
+		"claims": {
+			Description: "OpenID Claims config.",
+			Attributes:  openidClaimsSchema(),
+			Required:    true,
+		},
+		"client_id": {
+			Description: "Client ID from the registered application.",
+			Type:        types.StringType,
+			Required:    true,
+		},
+		"client_secret": {
+			Description: "Client Secret from the registered application.",
+			Type:        types.StringType,
+			Required:    true,
+			Sensitive:   true,
+		},
+		"extra_scopes": {
+			Description: "List of scopes to request, in addition to the 'openid' scope, during the authorization token request.",
+			Type: types.ListType{
+				ElemType: types.StringType,
+			},
+			Optional: true,
+		},
+		"extra_authorize_parameters": {
+			Type: types.ListType{
+				ElemType: types.StringType,
+			},
+			Optional: true,
+		},
+		"issuer": {
+			Description: "The URL that the OpenID Provider asserts as the Issuer Identifier. It must use the https scheme with no URL query parameters or fragment.",
+			Type:        types.StringType,
+			Required:    true,
+		},
+	})
+}
+
+func openidClaimsSchema() tfsdk.NestedAttributes {
+	return tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
+		"email": {
+			Description: "List of claims to use as the email address.",
+			Type: types.ListType{
+				ElemType: types.StringType,
+			},
+			Optional: true,
+		},
+		"groups": {
+			Description: "List of claims to use as the groups names.",
+			Type: types.ListType{
+				ElemType: types.StringType,
+			},
+			Optional: true,
+		},
+		"name": {
+			Description: "List of claims to use as the display name.",
+			Type: types.ListType{
+				ElemType: types.StringType,
+			},
+			Optional: true,
+		},
+		"preferred_username": {
+			Description: "List of claims to use as the preferred username when provisioning a user.",
+			Type: types.ListType{
+				ElemType: types.StringType,
+			},
+			Optional: true,
+		},
+	})
+}
+
+func CreateOpenIDIDPBuilder(ctx context.Context, state *OpenIDIdentityProvider) (*cmv1.OpenIDIdentityProviderBuilder, error) {
+	builder := cmv1.NewOpenIDIdentityProvider()
+	if !state.CA.Null {
+		builder.CA(state.CA.Value)
+	}
+	if state.Claims != nil {
+		claimsBuilder := cmv1.NewOpenIDClaims()
+
+		if !state.Claims.Groups.Unknown && !state.Claims.Groups.Null {
+			groups, err := common.StringListToArray(state.Claims.Groups)
+			if err != nil {
+				return nil, err
+			}
+			claimsBuilder.Groups(groups...)
+		}
+		if !state.Claims.EMail.Unknown && !state.Claims.EMail.Null {
+			emails, err := common.StringListToArray(state.Claims.EMail)
+			if err != nil {
+				return nil, err
+			}
+			claimsBuilder.Email(emails...)
+		}
+		if !state.Claims.Name.Unknown && !state.Claims.Name.Null {
+			names, err := common.StringListToArray(state.Claims.Name)
+			if err != nil {
+				return nil, err
+			}
+			claimsBuilder.Name(names...)
+		}
+		if !state.Claims.PreferredUsername.Unknown && !state.Claims.PreferredUsername.Null {
+			usernames, err := common.StringListToArray(state.Claims.PreferredUsername)
+			if err != nil {
+				return nil, err
+			}
+			claimsBuilder.PreferredUsername(usernames...)
+		}
+
+		builder.Claims(claimsBuilder)
+	}
+	if !state.ClientID.Null {
+		builder.ClientID(state.ClientID.Value)
+	}
+	if !state.ClientSecret.Null {
+		builder.ClientSecret(state.ClientSecret.Value)
+	}
+	if state.ExtraAuthorizeParameters != nil {
+		builder.ExtraAuthorizeParameters(state.ExtraAuthorizeParameters)
+	}
+	if !state.ExtraScopes.Unknown && !state.ExtraScopes.Null {
+		extraScopes, err := common.StringListToArray(state.ExtraScopes)
+		if err != nil {
+			return nil, err
+		}
+		builder.ExtraScopes(extraScopes...)
+	}
+	if !state.Issuer.Null {
+		builder.Issuer(state.Issuer.Value)
+	}
+	return builder, nil
+}


### PR DESCRIPTION
All IDPs are now located in /provider/idps/

this includes:
 - schemas
 - structs (states)
 - validations (if exists)
 - updated golang string slices to terraform types.List
 - Added missing descriptions + updated docs
 - provider builders