### PR TITLE
OCM-136: Allow specifying channel group name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/golang-jwt/jwt/v4 v4.4.3 // indirect
 	github.com/golang/glog v1.0.0 // indirect
@@ -66,6 +67,7 @@ require (
 	github.com/jackc/pgx/v4 v4.16.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.3 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
@@ -84,12 +86,14 @@ require (
 	github.com/prometheus/procfs v0.9.0 // indirect
 	github.com/russross/blackfriday v1.6.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
+	github.com/sirupsen/logrus v1.6.0 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/cobra v1.1.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/zclconf/go-cty v1.10.0 // indirect
 	github.com/zgalor/weberr v0.6.0 // indirect
+	gitlab.com/c0b/go-ordered-json v0.0.0-20171130231205-49bbdab258c2 // indirect
 	golang.org/x/crypto v0.1.0 // indirect
 	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect
@@ -99,5 +103,6 @@ require (
 	google.golang.org/grpc v1.32.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,7 @@ github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=
@@ -165,6 +166,7 @@ github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
+github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -378,6 +380,7 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -542,6 +545,7 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
@@ -592,6 +596,8 @@ github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRK
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 github.com/zgalor/weberr v0.6.0 h1:k6XSpFcOUNco8qtyAMBqXbCAVUivV7mRxGE5CMqHHdM=
 github.com/zgalor/weberr v0.6.0/go.mod h1:cqK89mj84q3PRgqQXQFWJDzCorOd8xOtov/ulOnqDwc=
+gitlab.com/c0b/go-ordered-json v0.0.0-20171130231205-49bbdab258c2 h1:M+r1hdmjZc4L4SCn0ZIq/5YQIRxprV+kOf7n7f04l5o=
+gitlab.com/c0b/go-ordered-json v0.0.0-20171130231205-49bbdab258c2/go.mod h1:NREvu3a57BaK0R1+ztrEzHWiZAihohNLQ6trPxlIqZI=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=

--- a/provider/cluster_rosa_classic_resource.go
+++ b/provider/cluster_rosa_classic_resource.go
@@ -670,9 +670,9 @@ func createClassicClusterObject(ctx context.Context,
 	return object, err
 }
 
-// getAndValidateVersion ensures that the cluster version is available in the
-// channel group
-func (r *ClusterRosaClassicResource) getAndValidateVersion(ctx context.Context, state *ClusterRosaClassicState) (string, error) {
+// getAndValidateVersionInChannelGroup ensures that the cluster version is
+// available in the channel group
+func (r *ClusterRosaClassicResource) getAndValidateVersionInChannelGroup(ctx context.Context, state *ClusterRosaClassicState) (string, error) {
 	channelGroup := ocm.DefaultChannelGroup
 	if !state.ChannelGroup.Unknown && !state.ChannelGroup.Null {
 		channelGroup = state.ChannelGroup.Value
@@ -701,7 +701,7 @@ func (r *ClusterRosaClassicResource) getAndValidateVersion(ctx context.Context, 
 func (r *ClusterRosaClassicResource) validateAccountRoles(ctx context.Context, state *ClusterRosaClassicState) error {
 	r.logger.Debug(ctx, "Validating if cluster version is compatible to account roles' version")
 	region := state.CloudRegion.Value
-	version, err := r.getAndValidateVersion(ctx, state)
+	version, err := r.getAndValidateVersionInChannelGroup(ctx, state)
 	if err != nil {
 		return fmt.Errorf("Could not get cluster version: %v", err)
 	}

--- a/provider/cluster_rosa_classic_resource_test.go
+++ b/provider/cluster_rosa_classic_resource_test.go
@@ -147,7 +147,7 @@ func generateBasicRosaClassicClusterState() *ClusterRosaClassicState {
 			},
 		},
 		ChannelGroup: types.String{
-			Value: "somechannel",
+			Value: "stable",
 		},
 		Version: types.String{
 			Value: "4.10",
@@ -196,7 +196,7 @@ var _ = Describe("Rosa Classic Sts cluster", func() {
 			Expect(version).To(Equal("4.10"))
 			channel, ok := rosaClusterObject.Version().GetChannelGroup()
 			Expect(ok).To(BeTrue())
-			Expect(channel).To(Equal("somechannel"))
+			Expect(channel).To(Equal("stable"))
 		})
 	})
 
@@ -212,6 +212,20 @@ var _ = Describe("Rosa Classic Sts cluster", func() {
 		clusterState.Version.Value = "4.1.0"
 		_, err := createClassicClusterObject(context.Background(), clusterState, &logging.StdLogger{}, diag.Diagnostics{})
 		Expect(err).ToNot(BeNil())
+	})
+
+	It("appends the non-default channel name to the requested version", func() {
+		clusterState := generateBasicRosaClassicClusterState()
+		clusterState.ChannelGroup.Value = "somechannel"
+		rosaClusterObject, err := createClassicClusterObject(context.Background(), clusterState, &logging.StdLogger{}, diag.Diagnostics{})
+		Expect(err).To(BeNil())
+
+		version, ok := rosaClusterObject.Version().GetID()
+		Expect(ok).To(BeTrue())
+		Expect(version).To(Equal("4.10-somechannel"))
+		channel, ok := rosaClusterObject.Version().GetChannelGroup()
+		Expect(ok).To(BeTrue())
+		Expect(channel).To(Equal("somechannel"))
 	})
 
 	Context("populateRosaClassicClusterState", func() {

--- a/provider/cluster_rosa_classic_resource_test.go
+++ b/provider/cluster_rosa_classic_resource_test.go
@@ -146,6 +146,9 @@ func generateBasicRosaClassicClusterState() *ClusterRosaClassicState {
 				},
 			},
 		},
+		ChannelGroup: types.String{
+			Value: "somechannel",
+		},
 		Version: types.String{
 			Value: "4.10",
 		},
@@ -187,6 +190,13 @@ var _ = Describe("Rosa Classic Sts cluster", func() {
 			arn, ok := rosaClusterObject.Properties()["rosa_creator_arn"]
 			Expect(ok).To(BeTrue())
 			Expect(arn).To(Equal(rosaCreatorArn))
+
+			version, ok := rosaClusterObject.Version().GetID()
+			Expect(ok).To(BeTrue())
+			Expect(version).To(Equal("4.10"))
+			channel, ok := rosaClusterObject.Version().GetChannelGroup()
+			Expect(ok).To(BeTrue())
+			Expect(channel).To(Equal("somechannel"))
 		})
 	})
 

--- a/provider/cluster_rosa_classic_state.go
+++ b/provider/cluster_rosa_classic_state.go
@@ -31,6 +31,7 @@ type ClusterRosaClassicState struct {
 	AutoScalingEnabled        types.Bool   `tfsdk:"autoscaling_enabled"`
 	MinReplicas               types.Int64  `tfsdk:"min_replicas"`
 	MaxReplicas               types.Int64  `tfsdk:"max_replicas"`
+	ChannelGroup              types.String `tfsdk:"channel_group"`
 	CloudRegion               types.String `tfsdk:"cloud_region"`
 	ComputeMachineType        types.String `tfsdk:"compute_machine_type"`
 	DefaultMPLabels           types.Map    `tfsdk:"default_mp_labels"`


### PR DESCRIPTION
- [x] Add a new attribute
- [x] Validate the cluster version including the channel group
- [x] Validate the version of the account roles is compatible to that version
- [x] Send the ChannelGroup as part of the object NewCluster