### PR TITLE
OCM-141: Terraform for IMDSv2 support

### DIFF
--- a/docs/resources/cluster_rosa_classic.md
+++ b/docs/resources/cluster_rosa_classic.md
@@ -25,6 +25,7 @@ OpenShift managed cluster using rosa sts.
 
 - `autoscaling_enabled` (Boolean) Enables autoscaling.
 - `availability_zones` (List of String) availability zones
+- `aws_http_tokens_state` (String) Which http_tokens_state to use for metadata service interaction options for EC2 instancescan be optional or required, available from ocp v4.11.0
 - `aws_private_link` (Boolean) Provides private connectivity between VPCs, AWS services, and your on-premises networks, without exposing your traffic to the public internet.
 - `aws_subnet_ids` (List of String) aws subnet ids
 - `compute_machine_type` (String) Identifier of the machine type used by the compute nodes, for example `r5.xlarge`. Use the `ocm_machine_types` data source to find the possible values.

--- a/docs/resources/machine_pool.md
+++ b/docs/resources/machine_pool.md
@@ -19,18 +19,18 @@ Machine pool.
 
 - `cluster` (String) Identifier of the cluster.
 - `machine_type` (String) Identifier of the machine type used by the nodes, for example `r5.xlarge`. Use the `ocm_machine_types` data source to find the possible values.
-- `name` (String) Name of the machine pool. Must consist of lower-case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
+- `name` (String) Name of the machine pool.Must consist of lower-case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
 
 ### Optional
 
 - `autoscaling_enabled` (Boolean) Enables autoscaling.
 - `labels` (Map of String) Labels for machine pool. Format should be a comma-separated list of 'key = value'. This list will overwrite any modifications made to node labels on an ongoing basis..
 - `max_replicas` (Number) Max replicas.
+- `max_spot_price` (Number) Max Spot price.
 - `min_replicas` (Number) Min replicas.
 - `replicas` (Number) The number of machines of the pool
 - `taints` (Attributes List) Taints for machine pool. Format should be a comma-separated list of 'key=value:ScheduleType'. This list will overwrite any modifications made to node taints on an ongoing basis. (see [below for nested schema](#nestedatt--taints))
-- `use_spot_instances`(Boolean) Use Spot Instances.
-- `max_spot_price` (Float) Max Spot price. Default value to set maximum spot price as on-demand price.
+- `use_spot_instances` (Boolean) Use Spot Instances.
 
 ### Read-Only
 
@@ -44,3 +44,5 @@ Required:
 - `key` (String) Taints key
 - `schedule_type` (String) Taints schedule type
 - `value` (String) Taints value
+
+

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.5.0
 	github.com/onsi/ginkgo/v2 v2.4.0
 	github.com/onsi/gomega v1.23.0
-	github.com/openshift-online/ocm-sdk-go v0.1.338
+	github.com/openshift-online/ocm-sdk-go v0.1.339
 	github.com/openshift/rosa v1.2.21
 	github.com/pkg/errors v0.9.1
 	github.com/segmentio/ksuid v1.0.4
@@ -87,6 +87,7 @@ require (
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/cobra v1.1.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/thoas/go-funk v0.9.3 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/zclconf/go-cty v1.10.0 // indirect
 	github.com/zgalor/weberr v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -471,8 +471,8 @@ github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAl
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
 github.com/onsi/gomega v1.23.0 h1:/oxKu9c2HVap+F3PfKort2Hw5DEU+HGlW8n+tguWsys=
 github.com/onsi/gomega v1.23.0/go.mod h1:Z/NWtiqwBrwUt4/2loMmHL63EDLnYHmVbuBpDr2vQAg=
-github.com/openshift-online/ocm-sdk-go v0.1.338 h1:8rmGtGW2bYVJ4ZFbFC4mMF8g+Ft0F0IT3qIXUf3F4CU=
-github.com/openshift-online/ocm-sdk-go v0.1.338/go.mod h1:KYOw8kAKAHyPrJcQoVR82CneQ4ofC02Na4cXXaTq4Nw=
+github.com/openshift-online/ocm-sdk-go v0.1.339 h1:/vQcIWX9N+zmpA79b8bzleUiW9oTeeP3/gkxSBUtlgE=
+github.com/openshift-online/ocm-sdk-go v0.1.339/go.mod h1:KYOw8kAKAHyPrJcQoVR82CneQ4ofC02Na4cXXaTq4Nw=
 github.com/openshift/rosa v1.2.21 h1:Jtf0s1jgdd6Pu0eo0scXSHHg79Yq+dAKemW0ApfYoB0=
 github.com/openshift/rosa v1.2.21/go.mod h1:gUs+GsvYxDvvtS8U1BgIQjDCSd0yrTDLOGpdTTKnWpg=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
@@ -570,6 +570,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/thoas/go-funk v0.9.3 h1:7+nAEx3kn5ZJcnDm2Bh23N2yOtweO14bi//dvRtgLpw=
+github.com/thoas/go-funk v0.9.3/go.mod h1:+IWnUfUmFO1+WVYQWQtIJHeRRdaIyyYglZN7xzUPe4Q=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=

--- a/provider/cluster_rosa_classic_resource_test.go
+++ b/provider/cluster_rosa_classic_resource_test.go
@@ -60,6 +60,7 @@ const (
 	roleArn           = "arn:aws:iam::123456789012:role/role-name"
 	httpProxy         = "http://proxy.com"
 	httpsProxy        = "https://proxy.com"
+	httpTokensState   = "required"
 )
 
 var (
@@ -108,8 +109,9 @@ func generateBasicRosaClassicClusterJson() map[string]interface{} {
 			"enabled": ccsEnabled,
 		},
 		"aws": map[string]interface{}{
-			"account_id":   awsAccountID,
-			"private_link": privateLink,
+			"account_id":        awsAccountID,
+			"private_link":      privateLink,
+			"http_tokens_state": httpTokensState,
 			"sts": map[string]interface{}{
 				"oidc_endpoint_url": oidcEndpointUrl,
 				"role_arn":          roleArn,
@@ -189,7 +191,6 @@ var _ = Describe("Rosa Classic Sts cluster", func() {
 			Expect(arn).To(Equal(rosaCreatorArn))
 		})
 	})
-
 	It("Throws an error when version format is invalid", func() {
 		clusterState := generateBasicRosaClassicClusterState()
 		clusterState.Version.Value = "a.4.1"
@@ -231,6 +232,7 @@ var _ = Describe("Rosa Classic Sts cluster", func() {
 			Expect(clusterState.AWSPrivateLink.Value).To(Equal(privateLink))
 			Expect(clusterState.Sts.OIDCEndpointURL.Value).To(Equal(oidcEndpointUrl))
 			Expect(clusterState.Sts.RoleARN.Value).To(Equal(roleArn))
+			Expect(clusterState.HttpTokensState.Value).To(Equal(httpTokensState))
 		})
 
 		It("Check trimming of oidc url with https perfix", func() {
@@ -267,4 +269,21 @@ var _ = Describe("Rosa Classic Sts cluster", func() {
 			Expect(clusterState.Sts.Thumbprint.Value).To(Equal(""))
 		})
 	})
+
+	Context("http tokens state validation", func() {
+		It("Fail validation with lower version than allowed", func() {
+			clusterState := generateBasicRosaClassicClusterState()
+			clusterState.HttpTokensState.Value = string(cmv1.HttpTokenStateOptional)
+			err := validateHttpTokensVersion(context.Background(), &logging.StdLogger{}, clusterState, "openshift-v4.10.0")
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring("is not supported with http tokens " +
+				"required, minimum supported version"))
+		})
+		It("Pass validation with http_tokens_state and supported version", func() {
+			clusterState := generateBasicRosaClassicClusterState()
+			err := validateHttpTokensVersion(context.Background(), &logging.StdLogger{}, clusterState, "openshift-v4.11.0")
+			Expect(err).To(BeNil())
+		})
+	})
+
 })

--- a/provider/cluster_rosa_classic_state.go
+++ b/provider/cluster_rosa_classic_state.go
@@ -57,6 +57,7 @@ type ClusterRosaClassicState struct {
 	Version                   types.String `tfsdk:"version"`
 	DisableWaitingInDestroy   types.Bool   `tfsdk:"disable_waiting_in_destroy"`
 	DestroyTimeout            types.Int64  `tfsdk:"destroy_timeout"`
+	HttpTokensState           types.String `tfsdk:"aws_http_tokens_state"`
 }
 
 type Sts struct {

--- a/provider/common/helpers.go
+++ b/provider/common/helpers.go
@@ -83,3 +83,7 @@ func StringListToArray(list types.List) ([]string, error) {
 	}
 	return arr, nil
 }
+
+func IsStringAttributeEmpty(param types.String) bool {
+	return param.Unknown || param.Null || param.Value == ""
+}

--- a/provider/enum_value_validator.go
+++ b/provider/enum_value_validator.go
@@ -1,0 +1,37 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"github.com/thoas/go-funk"
+
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/terraform-redhat/terraform-provider-ocm/provider/common"
+)
+
+func EnumValueValidator(allowedList []string) []tfsdk.AttributeValidator {
+	return []tfsdk.AttributeValidator{
+		&common.AttributeValidator{
+			Desc: "Validate enum param",
+			Validator: func(ctx context.Context, req tfsdk.ValidateAttributeRequest, resp *tfsdk.ValidateAttributeResponse) {
+
+				value := &types.String{}
+				diag := req.Config.GetAttribute(ctx, req.AttributePath, value)
+				if diag.HasError() || common.IsStringAttributeEmpty(*value) {
+					// No attribute to validate
+					return
+				}
+
+				if funk.Contains(allowedList, value.Value) {
+					return
+				}
+
+				resp.Diagnostics.AddError(fmt.Sprintf("Invalid %s.", req.AttributePath.LastStep()),
+					fmt.Sprintf("Expected a valid %s param. Options are %s. Got %s.",
+						req.AttributePath.LastStep(), allowedList, value.Value),
+				)
+			},
+		},
+	}
+}


### PR DESCRIPTION
        Adding support for http_tokens_state field. This field can be used only
        from 4.11.0 and have 2 options: optional/required