### PR TITLE
OCM-141: Terraform for IMDSv2 support

### DIFF
--- a/docs/resources/cluster_rosa_classic.md
+++ b/docs/resources/cluster_rosa_classic.md
@@ -25,6 +25,7 @@ OpenShift managed cluster using rosa sts.
 
 - `autoscaling_enabled` (Boolean) Enables autoscaling.
 - `availability_zones` (List of String) availability zones
+- `aws_http_tokens_state` (String) Which http_tokens_state to use for metadata service interaction options for EC2 instancescan be optional or required, available from ocp v4.11.0
 - `aws_private_link` (Boolean) Provides private connectivity between VPCs, AWS services, and your on-premises networks, without exposing your traffic to the public internet.
 - `aws_subnet_ids` (List of String) aws subnet ids
 - `compute_machine_type` (String) Identifier of the machine type used by the compute nodes, for example `r5.xlarge`. Use the `ocm_machine_types` data source to find the possible values.

--- a/docs/resources/machine_pool.md
+++ b/docs/resources/machine_pool.md
@@ -19,18 +19,18 @@ Machine pool.
 
 - `cluster` (String) Identifier of the cluster.
 - `machine_type` (String) Identifier of the machine type used by the nodes, for example `r5.xlarge`. Use the `ocm_machine_types` data source to find the possible values.
-- `name` (String) Name of the machine pool. Must consist of lower-case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
+- `name` (String) Name of the machine pool.Must consist of lower-case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
 
 ### Optional
 
 - `autoscaling_enabled` (Boolean) Enables autoscaling.
 - `labels` (Map of String) Labels for machine pool. Format should be a comma-separated list of 'key = value'. This list will overwrite any modifications made to node labels on an ongoing basis..
 - `max_replicas` (Number) Max replicas.
+- `max_spot_price` (Number) Max Spot price.
 - `min_replicas` (Number) Min replicas.
 - `replicas` (Number) The number of machines of the pool
 - `taints` (Attributes List) Taints for machine pool. Format should be a comma-separated list of 'key=value:ScheduleType'. This list will overwrite any modifications made to node taints on an ongoing basis. (see [below for nested schema](#nestedatt--taints))
-- `use_spot_instances`(Boolean) Use Spot Instances.
-- `max_spot_price` (Float) Max Spot price. Default value to set maximum spot price as on-demand price.
+- `use_spot_instances` (Boolean) Use Spot Instances.
 
 ### Read-Only
 
@@ -44,3 +44,5 @@ Required:
 - `key` (String) Taints key
 - `schedule_type` (String) Taints schedule type
 - `value` (String) Taints value
+
+

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.5.0
 	github.com/onsi/ginkgo/v2 v2.4.0
 	github.com/onsi/gomega v1.23.0
-	github.com/openshift-online/ocm-sdk-go v0.1.338
+	github.com/openshift-online/ocm-sdk-go v0.1.339
 	github.com/openshift/rosa v1.2.21
 	github.com/pkg/errors v0.9.1
 	github.com/segmentio/ksuid v1.0.4
@@ -90,6 +90,7 @@ require (
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/cobra v1.1.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/thoas/go-funk v0.9.3 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/zclconf/go-cty v1.10.0 // indirect
 	github.com/zgalor/weberr v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -474,8 +474,8 @@ github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAl
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
 github.com/onsi/gomega v1.23.0 h1:/oxKu9c2HVap+F3PfKort2Hw5DEU+HGlW8n+tguWsys=
 github.com/onsi/gomega v1.23.0/go.mod h1:Z/NWtiqwBrwUt4/2loMmHL63EDLnYHmVbuBpDr2vQAg=
-github.com/openshift-online/ocm-sdk-go v0.1.338 h1:8rmGtGW2bYVJ4ZFbFC4mMF8g+Ft0F0IT3qIXUf3F4CU=
-github.com/openshift-online/ocm-sdk-go v0.1.338/go.mod h1:KYOw8kAKAHyPrJcQoVR82CneQ4ofC02Na4cXXaTq4Nw=
+github.com/openshift-online/ocm-sdk-go v0.1.339 h1:/vQcIWX9N+zmpA79b8bzleUiW9oTeeP3/gkxSBUtlgE=
+github.com/openshift-online/ocm-sdk-go v0.1.339/go.mod h1:KYOw8kAKAHyPrJcQoVR82CneQ4ofC02Na4cXXaTq4Nw=
 github.com/openshift/rosa v1.2.21 h1:Jtf0s1jgdd6Pu0eo0scXSHHg79Yq+dAKemW0ApfYoB0=
 github.com/openshift/rosa v1.2.21/go.mod h1:gUs+GsvYxDvvtS8U1BgIQjDCSd0yrTDLOGpdTTKnWpg=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
@@ -574,6 +574,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/thoas/go-funk v0.9.3 h1:7+nAEx3kn5ZJcnDm2Bh23N2yOtweO14bi//dvRtgLpw=
+github.com/thoas/go-funk v0.9.3/go.mod h1:+IWnUfUmFO1+WVYQWQtIJHeRRdaIyyYglZN7xzUPe4Q=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=

--- a/provider/cluster_rosa_classic_state.go
+++ b/provider/cluster_rosa_classic_state.go
@@ -58,6 +58,7 @@ type ClusterRosaClassicState struct {
 	Version                   types.String `tfsdk:"version"`
 	DisableWaitingInDestroy   types.Bool   `tfsdk:"disable_waiting_in_destroy"`
 	DestroyTimeout            types.Int64  `tfsdk:"destroy_timeout"`
+	HttpTokensState           types.String `tfsdk:"aws_http_tokens_state"`
 }
 
 type Sts struct {

--- a/provider/common/helpers.go
+++ b/provider/common/helpers.go
@@ -17,12 +17,16 @@ limitations under the License.
 package common
 
 import (
+	"github.com/hashicorp/go-version"
 	"regexp"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/pkg/errors"
 )
+
+const versionPrefix = "openshift-v"
 
 // shouldPatchInt changed checks if the change between the given state and plan requires sending a
 // patch request to the server. If it does it returns the value to add to the patch.
@@ -89,4 +93,20 @@ func StringListToArray(list types.List) ([]string, error) {
 func IsValidDomain(candidate string) bool {
 	var domainRegexp = regexp.MustCompile(`^(?i)[a-z0-9-]+(\.[a-z0-9-]+)+\.?$`)
 	return domainRegexp.MatchString(candidate)
+}
+
+func IsStringAttributeEmpty(param types.String) bool {
+	return param.Unknown || param.Null || param.Value == ""
+}
+
+func IsGreaterThanOrEqual(version1, version2 string) (bool, error) {
+	v1, err := version.NewVersion(strings.TrimPrefix(version1, versionPrefix))
+	if err != nil {
+		return false, err
+	}
+	v2, err := version.NewVersion(strings.TrimPrefix(version2, versionPrefix))
+	if err != nil {
+		return false, err
+	}
+	return v1.GreaterThanOrEqual(v2), nil
 }

--- a/provider/enum_value_validator.go
+++ b/provider/enum_value_validator.go
@@ -1,0 +1,37 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"github.com/thoas/go-funk"
+
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/terraform-redhat/terraform-provider-ocm/provider/common"
+)
+
+func EnumValueValidator(allowedList []string) []tfsdk.AttributeValidator {
+	return []tfsdk.AttributeValidator{
+		&common.AttributeValidator{
+			Desc: "Validate enum param",
+			Validator: func(ctx context.Context, req tfsdk.ValidateAttributeRequest, resp *tfsdk.ValidateAttributeResponse) {
+
+				value := &types.String{}
+				diag := req.Config.GetAttribute(ctx, req.AttributePath, value)
+				if diag.HasError() || common.IsStringAttributeEmpty(*value) {
+					// No attribute to validate
+					return
+				}
+
+				if funk.Contains(allowedList, value.Value) {
+					return
+				}
+
+				resp.Diagnostics.AddError(fmt.Sprintf("Invalid %s.", req.AttributePath.LastStep()),
+					fmt.Sprintf("Expected a valid %s param. Options are %s. Got %s.",
+						req.AttributePath.LastStep(), allowedList, value.Value),
+				)
+			},
+		},
+	}
+}

--- a/subsystem/cluster_resource_rosa_test.go
+++ b/subsystem/cluster_resource_rosa_test.go
@@ -1188,7 +1188,7 @@ var _ = Describe("Cluster creation", func() {
 		// Run the apply command:
 		terraform.Source(`
 		  resource "ocm_cluster_rosa_classic" "my_cluster" {
-		    name           = "my-cluster"	
+		    name           = "my-cluster"
 		    cloud_region   = "us-west-1"
 			aws_account_id = "123"
 			version = "openshift-v4.12"
@@ -1207,4 +1207,194 @@ var _ = Describe("Cluster creation", func() {
 		Expect(terraform.Apply()).ToNot(BeZero())
 	})
 
+	It("Create cluster with http token", func() {
+		// Prepare the server:
+		server.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+				RespondWithJSON(http.StatusOK, versionListPage1),
+			),
+			CombineHandlers(
+				VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+				VerifyJQ(`.aws.http_tokens_state`, "required"),
+				RespondWithPatchedJSON(http.StatusCreated, template, `[
+					{
+					  "op": "add",
+					  "path": "/aws",
+					  "value": {
+                          "aws_http_tokens_state" : "required",
+						  "sts" : {
+							  "oidc_endpoint_url": "https://oidc_endpoint_url",
+							  "thumbprint": "111111",
+							  "role_arn": "",
+							  "support_role_arn": "",
+							  "instance_iam_roles" : {
+								"master_role_arn" : "",
+								"worker_role_arn" : ""
+							  },
+							  "operator_role_prefix" : "test"
+						  }
+					  }
+					},
+					{
+					  "op": "add",
+					  "path": "/nodes",
+					  "value": {
+						"compute": 3,
+						"compute_machine_type": {
+							"id": "r5.xlarge"
+						}
+					  }
+					}]`),
+			),
+		)
+
+		// Run the apply command:
+		terraform.Source(`
+		  resource "ocm_cluster_rosa_classic" "my_cluster" {
+		    name           = "my-cluster"
+		    cloud_region   = "us-west-1"
+			aws_account_id = "123"
+			aws_http_tokens_state = "required"
+			sts = {
+				operator_role_prefix = "test"
+				role_arn = "",
+				support_role_arn = "",
+				instance_iam_roles = {
+					master_role_arn = "",
+					worker_role_arn = "",
+				}
+			}
+		  }
+		`)
+		Expect(terraform.Apply()).To(BeZero())
+	})
+	It("Fails to create cluster with http tokens and not supported version", func() {
+		// Prepare the server:
+		server.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+				RespondWithJSON(http.StatusOK, versionListPage1),
+			),
+			CombineHandlers(
+				VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+				VerifyJQ(`.aws.http_tokens_state`, "required"),
+				RespondWithPatchedJSON(http.StatusCreated, template, `[
+					{
+					  "op": "add",
+					  "path": "/aws",
+					  "value": {
+                          "aws_http_tokens_state" : "required",
+						  "sts" : {
+							  "oidc_endpoint_url": "https://oidc_endpoint_url",
+							  "thumbprint": "111111",
+							  "role_arn": "",
+							  "support_role_arn": "",
+							  "instance_iam_roles" : {
+								"master_role_arn" : "",
+								"worker_role_arn" : ""
+							  },
+							  "operator_role_prefix" : "test"
+						  }
+					  }
+					},
+					{
+					  "op": "add",
+					  "path": "/nodes",
+					  "value": {
+						"compute": 3,
+						"compute_machine_type": {
+							"id": "r5.xlarge"
+						}
+					  }
+					}]`),
+			),
+		)
+
+		// Run the apply command:
+		terraform.Source(`
+		  resource "ocm_cluster_rosa_classic" "my_cluster" {
+		    name           = "my-cluster"
+		    cloud_region   = "us-west-1"
+			aws_account_id = "123"
+			aws_http_tokens_state = "required"
+			version = "openshift-v4.10"
+			sts = {
+				operator_role_prefix = "test"
+				role_arn = "",
+				support_role_arn = "",
+				instance_iam_roles = {
+					master_role_arn = "",
+					worker_role_arn = "",
+				}
+			}
+		  }
+		`)
+		// expect to get an error
+		Expect(terraform.Apply()).ToNot(BeZero())
+	})
+	It("Fails to create cluster with http tokens with not supported value", func() {
+		// Prepare the server:
+		server.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+				RespondWithJSON(http.StatusOK, versionListPage1),
+			),
+			CombineHandlers(
+				VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+				VerifyJQ(`.aws.http_tokens_state`, "bad_string"),
+				RespondWithPatchedJSON(http.StatusCreated, template, `[
+					{
+					  "op": "add",
+					  "path": "/aws",
+					  "value": {
+                          "aws_http_tokens_state" : "bad_string",
+						  "sts" : {
+							  "oidc_endpoint_url": "https://oidc_endpoint_url",
+							  "thumbprint": "111111",
+							  "role_arn": "",
+							  "support_role_arn": "",
+							  "instance_iam_roles" : {
+								"master_role_arn" : "",
+								"worker_role_arn" : ""
+							  },
+							  "operator_role_prefix" : "test"
+						  }
+					  }
+					},
+					{
+					  "op": "add",
+					  "path": "/nodes",
+					  "value": {
+						"compute": 3,
+						"compute_machine_type": {
+							"id": "r5.xlarge"
+						}
+					  }
+					}]`),
+			),
+		)
+
+		// Run the apply command:
+		terraform.Source(`
+		  resource "ocm_cluster_rosa_classic" "my_cluster" {
+		    name           = "my-cluster"
+		    cloud_region   = "us-west-1"
+			aws_account_id = "123"
+			aws_http_tokens_state = "bad_string"
+			version = "openshift-v4.12"
+			sts = {
+				operator_role_prefix = "test"
+				role_arn = "",
+				support_role_arn = "",
+				instance_iam_roles = {
+					master_role_arn = "",
+					worker_role_arn = "",
+				}
+			}
+		  }
+		`)
+		// expect to get an error
+		Expect(terraform.Apply()).ToNot(BeZero())
+	})
 })


### PR DESCRIPTION
    Adding support for http_tokens_state field. This field can be used only
    from 4.11.0 and have 2 options: optional/required