### PR TITLE
Fix e2e flow missing variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,6 @@ tools:
 e2e_test: tools install
 	ginkgo run $(ginkgo_flags) \
 		--timeout 5h \
-		--junit-report ../../junit.xml \
 		-r \
 		--focus-file ci/e2e/.* \
 		-- \

--- a/ci/e2e/terraform_provider_ocm_fullcycle_test.go
+++ b/ci/e2e/terraform_provider_ocm_fullcycle_test.go
@@ -282,6 +282,7 @@ var _ = FDescribe("Terraform provider OCM test", Ordered, func() {
 			"-var", accountRolePrefix,
 			"-var", ocmEnvironment,
 			"-var", openshiftVersion,
+			"-var", gatewayFilter,
 			"-auto-approve"})
 
 		// remove temporary directories

--- a/ci/e2e/terraform_provider_ocm_fullcycle_test.go
+++ b/ci/e2e/terraform_provider_ocm_fullcycle_test.go
@@ -182,6 +182,8 @@ func createAccountRolesUsingTerraformAWSRosaStsModule(ctx context.Context) {
 		"-var", accountRolePrefix,
 		"-var", ocmEnvironment,
 		"-var", openshiftVersion,
+		"-var", tokenFilter,
+		"-var", gatewayFilter,
 		"-auto-approve"})
 }
 
@@ -226,10 +228,10 @@ func defineVariablesValues() {
 	accountRolePrefix = fmt.Sprintf("account_role_prefix=terr-account-%s", randSuffix)
 	logger.Info(ctx, "The account IAM role prefix that was chose is %s", accountRolePrefix)
 
-	ocmEnvironment = fmt.Sprintf("ocm_env=%s", URLAliases[args.gatewayURL])
+	ocmEnvironment = fmt.Sprintf("ocm_environment=%s", URLAliases[args.gatewayURL])
 	logger.Info(ctx, "The ocm environment that was chose is %s", ocmEnvironment)
 
-	openshiftVersion = fmt.Sprintf("rosa_openshift_version=%s", args.openshiftVersion)
+	openshiftVersion = fmt.Sprintf("openshift_version=%s", args.openshiftVersion)
 	logger.Info(ctx, "The cluster version that was chose is %s", openshiftVersion)
 
 	tokenFilter = fmt.Sprintf("token=%s", args.offlineToken)


### PR DESCRIPTION
Some variables were missing or given with the wrong names.
In addition, remove junit.xml reporting as we don't really use it right now (and it's causing some permission problems in prow)