### PR TITLE
Fixing issue with empty aws_http_tokens in ocm response

### DIFF
--- a/provider/cluster_rosa_classic_resource.go
+++ b/provider/cluster_rosa_classic_resource.go
@@ -1399,7 +1399,7 @@ func populateRosaClassicClusterState(ctx context.Context, object *cmv1.Cluster, 
 	}
 
 	httpTokensState, ok := object.AWS().GetHttpTokensState()
-	if ok {
+	if ok && httpTokensState != "" {
 		state.HttpTokensState = types.String{
 			Value: string(httpTokensState),
 		}


### PR DESCRIPTION
It fixed e2e test error
│ Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to ocm_cluster_rosa_classic.rosa_sts_cluster,
│ provider "provider[\"terraform.local/local/ocm\"]" produced an unexpected
│ new value: .aws_http_tokens_state: was null, but now cty.StringVal("").
│ 
│ This is a bug in the provider, which should be reported in the provider's
│ own issue tracker.
╵
