### PR TITLE
fix account_roles to extract version from extended openshift_version

### DIFF
--- a/ci/e2e/account_roles_files/main.tf
+++ b/ci/e2e/account_roles_files/main.tf
@@ -28,7 +28,7 @@ module "create_account_roles"{
 
   account_role_prefix    = var.account_role_prefix
   ocm_environment        = var.ocm_environment
-  rosa_openshift_version = var.openshift_version
+  rosa_openshift_version = "${split(".", var.openshift_version)[0]}.${split(".", var.openshift_version)[1]}"
   account_role_policies  = data.ocm_policies.all_policies.account_role_policies
   operator_role_policies = data.ocm_policies.all_policies.operator_role_policies
 }

--- a/ci/e2e/terraform_provider_ocm_files/main.tf
+++ b/ci/e2e/terraform_provider_ocm_files/main.tf
@@ -33,6 +33,7 @@ data "aws_caller_identity" "current" {
 
 resource "ocm_cluster_rosa_classic" "rosa_sts_cluster" {
   name               = var.cluster_name
+  version            = "openshift-v${var.openshift_version}"
   cloud_region       = var.aws_region
   aws_account_id     = data.aws_caller_identity.current.account_id
   availability_zones = var.aws_availability_zones

--- a/ci/e2e/terraform_provider_ocm_files/variables.tf
+++ b/ci/e2e/terraform_provider_ocm_files/variables.tf
@@ -34,3 +34,8 @@ variable replicas {
     type = string
     default = "3"
 }
+
+variable openshift_version {
+    type = string
+    default = "4.12.15"
+}


### PR DESCRIPTION
1. In case openshift_Version is passed to cluster creation (as 4.12.15, 4.13.rc-7, etc) , the version for account_roles creation (rosa_openshift_version) can be extracted from this parameter
2. added channel variable (stable is the default)