### PR TITLE
Fix missing token variable when destroying roles

### DIFF
--- a/ci/e2e/terraform_provider_ocm_fullcycle_test.go
+++ b/ci/e2e/terraform_provider_ocm_fullcycle_test.go
@@ -279,6 +279,7 @@ var _ = FDescribe("Terraform provider OCM test", Ordered, func() {
 
 		// destroy account roles
 		runTerraformDestroyWithArgs(ctx, accountRolesTempDir, []string{
+			"-var", tokenFilter,
 			"-var", accountRolePrefix,
 			"-var", ocmEnvironment,
 			"-var", openshiftVersion,


### PR DESCRIPTION
It causes the following error:
```
var.token
  Enter a value: ╷
│ Error: No value for required variable
│
│   on variables.tf line 15:
│   15: variable token {
│
│ The root module input variable "token" is not set, and has no default
│ value. Use a -var or -var-file command line argument to provide a
value for
│ this variable.
╵
------------------------------
• [FAILED] [3522.636 seconds]
Terraform provider OCM test [AfterAll]
/alabama/terraform-provider-ocm/ci/e2e/terraform_provider_ocm_fullcycle_test.go:270
  Cluster creation
  /alabama/terraform-provider-ocm/ci/e2e/terraform_provider_ocm_fullcycle_test.go:263
    creates a cluster using terraform-provider-ocm
    /alabama/terraform-provider-ocm/ci/e2e/terraform_provider_ocm_fullcycle_test.go:264
```
(see
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/39090/rehearse-39090-periodic-ci-terraform-redhat-terraform-provider-ocm-main-e2e-periodic/1659145091782021120)

/cc @AsherShoshan 