### PR TITLE
Automatically prefix resources with the aws username

### DIFF
--- a/build/ci-tf-e2e.Dockerfile
+++ b/build/ci-tf-e2e.Dockerfile
@@ -1,30 +1,46 @@
 FROM registry.access.redhat.com/ubi8/ubi:latest
 WORKDIR /root
 
+RUN dnf install -y \
+    curl \
+    tar \
+    unzip \
+    python3 \
+    make \
+    jq \
+    httpd-tools \
+    git
+
 # oc
-RUN curl -Ls https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz |tar -C /usr/local/bin -xzf - oc
+RUN curl -Ls https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz | tar -C /usr/local/bin -xzf - oc
+
+# aws
+RUN curl -Ls "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o /tmp/awscliv2.zip && \
+    unzip /tmp/awscliv2.zip && \
+    ./aws/install && \
+    rm -f /tmp/awscliv2.zip
 
 # ocm
-RUN yum install -y wget &&\
-    wget https://github.com/openshift-online/ocm-cli/releases/download/v0.1.66/ocm-linux-amd64 -O /usr/local/bin/ocm && \
+RUN curl -Ls https://github.com/openshift-online/ocm-cli/releases/download/v0.1.66/ocm-linux-amd64 -o /usr/local/bin/ocm && \
     chmod +x /usr/local/bin/ocm
 
 # go
-RUN curl -Ls https://go.dev/dl/go1.18.linux-amd64.tar.gz |tar -C /usr/local -xzf -
+RUN curl -Ls https://go.dev/dl/go1.18.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 ENV PATH="/usr/local/go/bin:${PATH}"
 ENV GOPATH=/usr/local/go
+RUN go env -w GO111MODULE=on
 ENV TEST_OFFLINE_TOKEN=""
+
+# terraform
+RUN dnf install -y 'dnf-command(config-manager)' && \
+    dnf config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo && \
+    dnf install -y terraform
 
 # terraform-provider-ocm repo
 COPY . ./terraform-provider-ocm
 
-RUN yum install -y yum-utils && \
-    yum-config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo &&\
-    yum -y install terraform python3 make jq httpd-tools git &&\
-    pip3 install PyYAML jinja2 &&\
-    go env -w GO111MODULE=on &&\
-    go install github.com/onsi/ginkgo/v2/ginkgo@latest &&\
-    go install github.com/golang/mock/mockgen@v1.6.0 &&\
-    cd terraform-provider-ocm && go mod tidy && go mod vendor && make install &&\
-    chmod -R 777 $GOPATH &&\
-    echo 'RUN done'
+RUN pip3 install PyYAML jinja2 && \
+    go install github.com/onsi/ginkgo/v2/ginkgo@latest && \
+    go install github.com/golang/mock/mockgen@v1.6.0 && \
+    cd terraform-provider-ocm && make install && \
+    chmod -R 777 $GOPATH

--- a/ci/e2e/terraform_provider_ocm_fullcycle_test.go
+++ b/ci/e2e/terraform_provider_ocm_fullcycle_test.go
@@ -213,26 +213,31 @@ func defineVariablesValues() {
 	randSuffix = rand.String(4)
 	logger.Info(ctx, "The random suffix that was chosen is %s", randSuffix)
 
+	awsUserOutput, err := exec.Command("aws", "iam", "get-user", "--query", "User.UserName", "--output", "text").Output()
+	helper.CheckError(err)
+	awsUser := strings.TrimSpace(string(awsUserOutput))
+
 	providerTempDir = fmt.Sprintf("%s_%s", terraformProviderOCMFilesDir, randSuffix)
 	logger.Info(ctx, "The temp directory that was chosen is %s", providerTempDir)
 
 	accountRolesTempDir = fmt.Sprintf("%s_%s", accountRolesFilesDir, randSuffix)
 	logger.Info(ctx, "The temp directory that was chosen is %s", accountRolesTempDir)
 
-	clusterName = fmt.Sprintf("cluster_name=ci-ocm-tf-%s", randSuffix)
+	truncatedClusterName := string([]rune(fmt.Sprintf("%s-%s", awsUser, randSuffix))[:15])  // cluster-name limited to 15 chars
+	clusterName = fmt.Sprintf("cluster_name=%s", truncatedClusterName)
 	logger.Info(ctx, "The cluster name that was chosen is %s", clusterName)
 
-	operatorRolePrefix = fmt.Sprintf("operator_role_prefix=terr-operator-%s", randSuffix)
-	logger.Info(ctx, "The operator IAM role prefix that was chose is %s", operatorRolePrefix)
+	operatorRolePrefix = fmt.Sprintf("operator_role_prefix=%s-e2e-tf-operator-%s", awsUser, randSuffix)
+	logger.Info(ctx, "The operator IAM role prefix that was chosen is %s", operatorRolePrefix)
 
-	accountRolePrefix = fmt.Sprintf("account_role_prefix=terr-account-%s", randSuffix)
-	logger.Info(ctx, "The account IAM role prefix that was chose is %s", accountRolePrefix)
+	accountRolePrefix = fmt.Sprintf("account_role_prefix=%s-e2e-tf-account-%s", awsUser, randSuffix)
+	logger.Info(ctx, "The account IAM role prefix that was chosen is %s", accountRolePrefix)
 
 	ocmEnvironment = fmt.Sprintf("ocm_environment=%s", URLAliases[args.gatewayURL])
-	logger.Info(ctx, "The ocm environment that was chose is %s", ocmEnvironment)
+	logger.Info(ctx, "The ocm environment that was chosen is %s", ocmEnvironment)
 
 	openshiftVersion = fmt.Sprintf("openshift_version=%s", args.openshiftVersion)
-	logger.Info(ctx, "The cluster version that was chose is %s", openshiftVersion)
+	logger.Info(ctx, "The cluster version that was chosen is %s", openshiftVersion)
 
 	tokenFilter = fmt.Sprintf("token=%s", args.offlineToken)
 


### PR DESCRIPTION
It has come to our attention that some of the resources are untagged. This makes it hard to correlate them with the initiating user, especially for cases where it's being run against a local CS env.

Here we first query the username from ``aws`` client (a preconfigured ``aws`` client is either way a requirement for using the provider) and prefixes the resources with this value.