### PR TITLE
OCM-274: Added 2 make targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .terraform*
 /dist/
 terraform.tfstate*
+/playground/*

--- a/Makefile
+++ b/Makefile
@@ -113,3 +113,12 @@ e2e_test: tools install
 		--offline-token=$(test_token) \
 		--openshift-version=$(openshift_version) \
 		$(NULL)
+
+.PHONY: apply_folder
+apply_folder: install
+	bash ./ci/apply_folder.sh
+
+.PHONY: destroy_folder
+destroy_folder: install
+	bash ./ci/destroy_folder.sh
+

--- a/README.md
+++ b/README.md
@@ -279,6 +279,16 @@ provider "ocm" {
   url = var.url
 }
 ```
+### Development playground
+You can create a `./playground/` folder in the root dir. Place your .tf files in the playground and run `make apply_folder`.
+
+This will build and install the provider, and will try to apply the folder. You can change the "playground" directory by by setting `$WORK_DIR`.
+```
+$ WORK_DIR="/tmp/my_tf_folder" make apply_folder
+```
+
+> Note: Don't forget to to pint to the local provider in your TF files.
+
 ## Testing binary
 If you want to test locally the provider binary without building from sources you can pull the `latest` container image and copy the binary from the directory :
 ```

--- a/ci/apply_folder.sh
+++ b/ci/apply_folder.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+trap 'CHILDREN=$(jobs -p); if test -n "${CHILDREN}"; then kill ${CHILDREN} && wait; fi' TERM
+
+function error_exit() {
+    msg=${1}
+    >&2 echo "[Error] ${msg}"
+    exit 1
+}
+
+function prow_archive_state() {
+    if [ -n "${OPENSHIFT_CI:-}" ]; then
+        echo
+        echo "[INFO] Running in OpenShift CI (Prow)."
+        echo "[INFO] Archiving state for PROW."
+        echo
+        set -o xtrace
+        tar cvfz "${STATE_ARCHIVE}" ./*.tf*  # For next steps to use
+        set +o xtrace
+        echo "[INFO] ${STATE_ARCHIVE} created."
+    fi
+
+    if [ -n "${1:-}" ]; then
+        error_exit "TF command failed."
+    fi
+}
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+BASE_DIR=$(realpath "${THIS_DIR}/..")
+
+echo
+echo ">> Running apply_folder script"
+echo "   ---------------------------"
+echo
+if [ -n "${OPENSHIFT_CI:-}" ]; then
+    source "${THIS_DIR}/setup_prow_env.sh"
+fi
+
+# Setup defaults
+TERRAFORM_D_DIR=${TERRAFORM_D_DIR:-"${HOME}"}
+WORK_DIR=${WORK_DIR:-"${BASE_DIR}/playground"}
+
+echo "[INFO] Will apply folder."
+echo "[INFO] - WORK_DIR: ${WORK_DIR}"
+echo "[INFO] - TERRAFORM_D_DIR: ${TERRAFORM_D_DIR}"
+echo "[INFO] - THIS_DIR: ${THIS_DIR}"
+echo "[INFO] - BASE_DIR: ${BASE_DIR}"
+
+if [[ ! -d ${WORK_DIR} ]]; then
+    error_exit "can't load WORK_DIR"
+fi
+
+set -o xtrace
+
+cd "${WORK_DIR}"
+HOME=${TERRAFORM_D_DIR} terraform init
+HOME=${TERRAFORM_D_DIR} terraform apply -auto-approve || prow_archive_state "true"
+
+set +o xtrace
+
+prow_archive_state
+
+if [ -n "${OPENSHIFT_CI:-}" ]; then
+    source "${THIS_DIR}/post_apply_prow_setup.sh"
+fi
+
+echo
+echo "[INFO] Finished applying the terraform folder ${WORK_DIR} successfully"
+echo

--- a/ci/destroy_folder.sh
+++ b/ci/destroy_folder.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+trap 'CHILDREN=$(jobs -p); if test -n "${CHILDREN}"; then kill ${CHILDREN} && wait; fi' TERM
+
+function error_exit() {
+    msg=${1}
+    >&2 echo "[Error] ${msg}"
+    exit 1
+}
+
+function prow_archive_state() {
+    if [ -n "${OPENSHIFT_CI:-}" ]; then
+        echo
+        echo "[INFO] Running in OpenShift CI (Prow)."
+        echo "[INFO] Archiving state for PROW."
+        echo
+        set -o xtrace
+        tar cvfz "${STATE_ARCHIVE}" ./*.tf*  # For next steps to use
+        set +o xtrace
+        echo "[INFO] ${STATE_ARCHIVE} created."
+    fi
+
+    if [ -n "${1:-}" ]; then
+        error_exit "TF command failed."
+    fi
+}
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+BASE_DIR=$(realpath "${THIS_DIR}/..")
+
+echo
+echo ">> Running destroy_folder script"
+echo "   -----------------------------"
+echo
+if [ -n "${OPENSHIFT_CI:-}" ]; then
+    source "${THIS_DIR}/setup_prow_env.sh"
+fi
+
+# Setup defaults
+TERRAFORM_D_DIR=${TERRAFORM_D_DIR:-"${HOME}"}
+WORK_DIR=${WORK_DIR:-"${BASE_DIR}/playground"}
+
+echo "[INFO] Will apply folder."
+echo "[INFO] - WORK_DIR: ${WORK_DIR}"
+echo "[INFO] - TERRAFORM_D_DIR: ${TERRAFORM_D_DIR}"
+echo "[INFO] - THIS_DIR: ${THIS_DIR}"
+echo "[INFO] - BASE_DIR: ${BASE_DIR}"
+
+if [[ ! -d ${WORK_DIR} ]]; then
+    error_exit "can't load WORK_DIR"
+fi
+
+set -o xtrace
+
+cd "${WORK_DIR}"
+HOME=${TERRAFORM_D_DIR} terraform init
+HOME=${TERRAFORM_D_DIR} terraform destroy -auto-approve || prow_archive_state "true"
+
+set +o xtrace
+
+prow_archive_state
+
+echo
+echo "[INFO] Finished destroying the terraform folder ${WORK_DIR} successfully"
+echo

--- a/ci/post_apply_prow_setup.sh
+++ b/ci/post_apply_prow_setup.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# This file should be sourced in a wrapper script (i.e apply_folder.sh)
+
+echo
+echo "[INFO] Running in OpenShift CI (Prow)."
+echo "[INFO] Post apply setup"
+echo
+
+cluster_id_tf=$(terraform output -json | jq -r '.cluster_id')
+if [[ "${cluster_id_tf}" != "null" ]]; then
+    echo "[INFO] Found cluster id... Setting up shared files."
+    cluster_id=$(echo "${cluster_id_tf}" | jq -r ".value")
+    echo "[INFO] Cluster ID: ${cluster_id}"
+    # Cluster ID
+    echo "${cluster_id}" > "${SHARED_DIR}/cluster_id"
+    # Kubeconfig
+    ocm login --token="${OCM_TOKEN}" --url="${GATEWAY_URL}"
+
+    creds=$(ocm get "/api/clusters_mgmt/v1/clusters/${cluster_id}/credentials")
+
+    echo "${creds}" | jq -r .kubeconfig  > "${SHARED_DIR}/kubeconfig"
+    echo "${creds}" | jq -r .admin.password > "${SHARED_DIR}/kubeadmin-password"
+
+    echo "[INFO] Kubeconfig and kubeadmin-password have been stored in shared directory"
+fi
+
+echo "[INFO] Done post PROW setup"
+echo

--- a/ci/setup_prow_env.sh
+++ b/ci/setup_prow_env.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# This file should be sourced in a wrapper script (i.e apply_folder.sh)
+
+echo
+echo "[INFO] Running in OpenShift CI (Prow)."
+echo "[INFO] Setting up for PROW"
+echo
+
+# Validate some mandatory variables
+if [ -z "${ARCHIVE_NAME:-}" ]; then
+    error_exit "missing mandatory variable \$ARCHIVE_NAME"
+fi
+
+if [ -z "${TF_FOLDER:-}" ]; then
+    error_exit "missing mandatory variable \$TF_FOLDER"
+fi
+
+if [ -z "${GATEWAY_URL:-}" ]; then
+    error_exit "missing mandatory variable \$GATEWAY_URL"
+fi
+echo "[INFO] OCM gateway url: ${GATEWAY_URL}"
+
+OCM_TOKEN=$(cat "${CLUSTER_PROFILE_DIR}/ocm-token")
+if [ -z "${OCM_TOKEN:-}" ]; then
+    error_exit "missing mandatory variable \$OCM_TOKEN"
+fi
+
+
+CLUSTER_NAME_FILE="${SHARED_DIR}/cluster-name"
+if [[ ! -f "${CLUSTER_NAME_FILE}" ]]; then
+    echo "ocm-tf-ci-$(mktemp -u XXXXX | tr '[:upper:]' '[:lower:]')" > "${CLUSTER_NAME_FILE}"
+fi
+CLUSTER_NAME=$(cat "${CLUSTER_NAME_FILE}")
+
+CLOUD_PROVIDER_REGION=${LEASED_RESOURCE}
+
+# Configure aws
+AWSCRED="${CLUSTER_PROFILE_DIR}/.awscred"
+if [[ -f "${AWSCRED}" ]]; then
+    export AWS_SHARED_CREDENTIALS_FILE="${AWSCRED}"
+    export AWS_DEFAULT_REGION="${CLOUD_PROVIDER_REGION}"
+else
+    error_exit "Did not find compatible cloud provider cluster_profile"
+fi
+
+export TERRAFORM_D_DIR=/root # location of .terraform.d folder
+export TF_VAR_token=${OCM_TOKEN}
+
+WORK_DIR=${SHARED_DIR}/work
+STATE_ARCHIVE="${SHARED_DIR}/${ARCHIVE_NAME}.tar.gz" 
+TFVARS_FILE="${WORK_DIR}/terraform.tfvars"
+
+rm -rf "${WORK_DIR}"
+mkdir "${WORK_DIR}"
+
+if [[ -f "${STATE_ARCHIVE}" ]]; then
+    echo "[INFO] Found TF state archive for '${ARCHIVE_NAME}' @ ${STATE_ARCHIVE}, extracting and ignoring \$TF_VARS"
+    tar xvfz "${SHARED_DIR}/${ARCHIVE_NAME}.tar.gz" -C "${WORK_DIR}"
+else
+    echo "[INFO] Did not find TF state, generating tfvars file."
+    { echo "account_role_prefix = \"${CLUSTER_NAME}\"";echo "operator_role_prefix = \"${CLUSTER_NAME}\"";echo "cluster_name = \"${CLUSTER_NAME}\"";} >> "${TFVARS_FILE}"
+    echo "${TF_VARS:-}" >> "${TFVARS_FILE}"
+fi
+
+echo "[INFO] TF vars:"
+cat "${TFVARS_FILE}"
+
+cp -r "${BASE_DIR}/${TF_FOLDER}"/* "${WORK_DIR}/"
+
+echo "[INFO] Done setting up for PROW run"
+echo


### PR DESCRIPTION
- apply_folder (./ci/apply_folder.sh)
- destroy_folder (./ci/destroy_folder.sh)

Targets can be run locally or from PROW CI.

Running locally will target the (gitignored) folder `./playground`. You
can use this to debug and play with local builds of the provider. To
change the default playground location, set `$WORK_DIR` before running
make.

If running in OpenShift CI, `$WORK_DIR` is set to
`${SHARED_DIR}/work`. And will handle archiving/extracting the
state to/from the `SHARED_DIR`. Also passing kubeconfig/cluster_id to the SHARED_DIR.

No Parameters are needed.