### PR TITLE
OCM-759: add error to "rosa_operator_roles_data_source" in case get stsOperatorRolesList failure

### DIFF
--- a/provider/rosa_operator_roles_data_source.go
+++ b/provider/rosa_operator_roles_data_source.go
@@ -131,7 +131,12 @@ func (t *RosaOperatorRolesDataSource) Read(ctx context.Context, request tfsdk.Re
 
 	stsOperatorRolesList, err := t.awsInquiries.STSCredentialRequests().List().Send()
 	if err != nil {
-		t.logger.Error(ctx, "Failed to get operator list")
+		description := fmt.Sprintf("Failed to get STS Operator Roles list with error: %v", err)
+		t.logger.Error(ctx, description)
+		response.Diagnostics.AddError(
+			description,
+			"hint: validate the credetials (token) used to run this provider",
+		)
 		return
 	}
 


### PR DESCRIPTION
In case failing to list the STS Operator Roles List "terraform apply" should fail and not continue to next step This is done in order to make it more clear for user what is the error In addition, added hint to user for checking the credentials (token)