### PR TITLE
Allow users to set cluster_name, cloud_region and hosted_zones

### DIFF
--- a/examples/create_rosa_cluster/create_rosa_iam_cluster/main.tf
+++ b/examples/create_rosa_cluster/create_rosa_iam_cluster/main.tf
@@ -31,8 +31,8 @@ provider "aws" {
   region = "us-east-1"
 }
 
-variable token {
-  type = string
+variable "token" {
+  type      = string
   sensitive = true
 }
 
@@ -52,14 +52,14 @@ resource "aws_iam_access_key" "admin_key" {
 }
 
 resource "ocm_cluster" "rosa_cluster" {
-  name           = "my-cluster"
-  cloud_provider = "aws"
-  cloud_region   = "us-east-1"
-  product        = "rosa"
-  aws_account_id     = data.aws_caller_identity.current.account_id
-  availability_zones = ["us-east-1a"]
+  name                  = "my-cluster"
+  cloud_provider        = "aws"
+  cloud_region          = "us-east-1"
+  product               = "rosa"
+  aws_account_id        = data.aws_caller_identity.current.account_id
+  availability_zones    = ["us-east-1a"]
   aws_access_key_id     = aws_iam_access_key.admin_key.id
-  aws_secret_access_key = aws_iam_access_key.admin_key.secret  
+  aws_secret_access_key = aws_iam_access_key.admin_key.secret
   properties = {
     rosa_creator_arn = data.aws_caller_identity.current.arn
   }

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/account_roles/main.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/account_roles/main.tf
@@ -29,22 +29,22 @@ terraform {
 
 provider "ocm" {
   token = var.token
-  url = var.url
+  url   = var.url
 }
 
-data "ocm_policies" "all_policies"{}
+data "ocm_policies" "all_policies" {}
 
-module "create_account_roles"{
-  source = "terraform-redhat/rosa-sts/aws"
+module "create_account_roles" {
+  source  = "terraform-redhat/rosa-sts/aws"
   version = ">=0.0.5"
 
   create_operator_roles = false
-  create_oidc_provider = false
-  create_account_roles = true
+  create_oidc_provider  = false
+  create_account_roles  = true
 
-  account_role_prefix =  var.account_role_prefix
-  ocm_environment =  var.ocm_environment
-  rosa_openshift_version=  var.openshift_version
-  account_role_policies=data.ocm_policies.all_policies.account_role_policies
-  operator_role_policies=data.ocm_policies.all_policies.operator_role_policies
+  account_role_prefix    = var.account_role_prefix
+  ocm_environment        = var.ocm_environment
+  rosa_openshift_version = var.openshift_version
+  account_role_policies  = data.ocm_policies.all_policies.account_role_policies
+  operator_role_policies = data.ocm_policies.all_policies.operator_role_policies
 }

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/account_roles/variables.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/account_roles/variables.tf
@@ -1,21 +1,21 @@
-variable ocm_environment {
-    type = string
-    default = "production"
+variable "ocm_environment" {
+  type    = string
+  default = "production"
 }
 
-variable openshift_version {
-    type = string
-    default = "4.12"
+variable "openshift_version" {
+  type    = string
+  default = "4.12"
 }
 
-variable account_role_prefix {
-    type = string
+variable "account_role_prefix" {
+  type = string
 }
 
-variable token {
-    type = string
+variable "token" {
+  type = string
 }
 
-variable url {
-    type = string
+variable "url" {
+  type = string
 }

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/account_roles/variables.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/account_roles/variables.tf
@@ -5,7 +5,7 @@ variable "ocm_environment" {
 
 variable "openshift_version" {
   type    = string
-  default = "4.12"
+  default = "4.13"
 }
 
 variable "account_role_prefix" {

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/cluster/main.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/cluster/main.tf
@@ -29,18 +29,18 @@ terraform {
 
 provider "ocm" {
   token = var.token
-  url = var.url
+  url   = var.url
 }
 
 locals {
   sts_roles = {
-      role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-Installer-Role",
-      support_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-Support-Role",
-      instance_iam_roles = {
-        master_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-ControlPlane-Role",
-        worker_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-Worker-Role"
-      },
-      operator_role_prefix = var.operator_role_prefix,
+    role_arn         = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-Installer-Role",
+    support_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-Support-Role",
+    instance_iam_roles = {
+      master_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-ControlPlane-Role",
+      worker_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-Worker-Role"
+    },
+    operator_role_prefix = var.operator_role_prefix,
   }
 }
 
@@ -48,8 +48,8 @@ data "aws_caller_identity" "current" {
 }
 
 resource "ocm_cluster_rosa_classic" "rosa_sts_cluster" {
-  name           = var.cluster_name
-  cloud_region   = var.cloud_region
+  name               = var.cluster_name
+  cloud_region       = var.cloud_region
   aws_account_id     = data.aws_caller_identity.current.account_id
   availability_zones = var.availability_zones
   properties = {
@@ -69,20 +69,20 @@ resource "ocm_cluster_wait" "rosa_cluster" {
 
 data "ocm_rosa_operator_roles" "operator_roles" {
   operator_role_prefix = var.operator_role_prefix
-  account_role_prefix = var.account_role_prefix
+  account_role_prefix  = var.account_role_prefix
 }
 
-module operator_roles {
-  source = "terraform-redhat/rosa-sts/aws"
+module "operator_roles" {
+  source  = "terraform-redhat/rosa-sts/aws"
   version = ">=0.0.5"
 
   create_operator_roles = true
-  create_oidc_provider = true
-  create_account_roles = false
+  create_oidc_provider  = true
+  create_account_roles  = false
 
-  cluster_id = ocm_cluster_rosa_classic.rosa_sts_cluster.id
+  cluster_id                  = ocm_cluster_rosa_classic.rosa_sts_cluster.id
   rh_oidc_provider_thumbprint = ocm_cluster_rosa_classic.rosa_sts_cluster.sts.thumbprint
-  rh_oidc_provider_url = ocm_cluster_rosa_classic.rosa_sts_cluster.sts.oidc_endpoint_url
-  operator_roles_properties = data.ocm_rosa_operator_roles.operator_roles.operator_iam_roles
+  rh_oidc_provider_url        = ocm_cluster_rosa_classic.rosa_sts_cluster.sts.oidc_endpoint_url
+  operator_roles_properties   = data.ocm_rosa_operator_roles.operator_roles.operator_iam_roles
 }
 

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/cluster/output.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/cluster/output.tf
@@ -1,11 +1,11 @@
-output cluster_id {
+output "cluster_id" {
   value = ocm_cluster_rosa_classic.rosa_sts_cluster.id
 }
 
-output oidc_thumbprint {
+output "oidc_thumbprint" {
   value = ocm_cluster_rosa_classic.rosa_sts_cluster.sts.thumbprint
 }
 
-output oidc_endpoint_url {
-   value = ocm_cluster_rosa_classic.rosa_sts_cluster.sts.oidc_endpoint_url
+output "oidc_endpoint_url" {
+  value = ocm_cluster_rosa_classic.rosa_sts_cluster.sts.oidc_endpoint_url
 }

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/cluster/variables.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/cluster/variables.tf
@@ -1,32 +1,32 @@
-variable token {
-  type = string
+variable "token" {
+  type      = string
   sensitive = true
 }
 
-variable operator_role_prefix {
-    type = string
+variable "operator_role_prefix" {
+  type = string
 }
 
-variable url {
-    type = string
-    default = "https://api.openshift.com"
+variable "url" {
+  type    = string
+  default = "https://api.openshift.com"
 }
 
-variable account_role_prefix {
-    type = string
+variable "account_role_prefix" {
+  type = string
 }
 
-variable cluster_name {
-    type = string
-    default = "my-cluster"
+variable "cluster_name" {
+  type    = string
+  default = "my-cluster"
 }
 
-variable cloud_region {
-    type = string
-    default = "us-east-2"
+variable "cloud_region" {
+  type    = string
+  default = "us-east-2"
 }
 
-variable availability_zones {
-    type = list(string)
-    default = ["us-east-2a"]
+variable "availability_zones" {
+  type    = list(string)
+  default = ["us-east-2a"]
 }

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/main.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/main.tf
@@ -70,10 +70,10 @@ data "aws_caller_identity" "current" {
 }
 
 resource "ocm_cluster_rosa_classic" "rosa_sts_cluster" {
-  name               = "tf-gdb-test"
-  cloud_region       = "us-east-2"
+  name               = var.cluster_name
+  cloud_region       = var.cloud_region
   aws_account_id     = data.aws_caller_identity.current.account_id
-  availability_zones = ["us-east-2a"]
+  availability_zones = var.availability_zones
   properties = {
     rosa_creator_arn = data.aws_caller_identity.current.arn
   }

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/main.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/main.tf
@@ -28,7 +28,7 @@ terraform {
 }
 provider "ocm" {
   token = var.token
-  url = var.url
+  url   = var.url
 }
 
 resource "ocm_rosa_oidc_config" "oidc_config" {
@@ -37,32 +37,32 @@ resource "ocm_rosa_oidc_config" "oidc_config" {
 
 data "ocm_rosa_operator_roles" "operator_roles" {
   operator_role_prefix = var.operator_role_prefix
-  account_role_prefix = var.account_role_prefix
+  account_role_prefix  = var.account_role_prefix
 }
 
-module operator_roles_and_oidc_provider {
-  source = "terraform-redhat/rosa-sts/aws"
+module "operator_roles_and_oidc_provider" {
+  source  = "terraform-redhat/rosa-sts/aws"
   version = ">=0.0.5"
 
   create_operator_roles = true
-  create_oidc_provider = true
+  create_oidc_provider  = true
 
-  cluster_id = ""
+  cluster_id                  = ""
   rh_oidc_provider_thumbprint = ocm_rosa_oidc_config.oidc_config.thumbprint
-  rh_oidc_provider_url = ocm_rosa_oidc_config.oidc_config.oidc_endpoint_url
-  operator_roles_properties = data.ocm_rosa_operator_roles.operator_roles.operator_iam_roles
+  rh_oidc_provider_url        = ocm_rosa_oidc_config.oidc_config.oidc_endpoint_url
+  operator_roles_properties   = data.ocm_rosa_operator_roles.operator_roles.operator_iam_roles
 }
 
 locals {
   sts_roles = {
-    role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-Installer-Role",
+    role_arn         = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-Installer-Role",
     support_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-Support-Role",
     instance_iam_roles = {
       master_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-ControlPlane-Role",
       worker_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-Worker-Role"
     },
     operator_role_prefix = var.operator_role_prefix,
-    oidc_config_id = ocm_rosa_oidc_config.oidc_config.id
+    oidc_config_id       = ocm_rosa_oidc_config.oidc_config.id
   }
 }
 
@@ -70,8 +70,8 @@ data "aws_caller_identity" "current" {
 }
 
 resource "ocm_cluster_rosa_classic" "rosa_sts_cluster" {
-  name           = "tf-gdb-test"
-  cloud_region   = "us-east-2"
+  name               = "tf-gdb-test"
+  cloud_region       = "us-east-2"
   aws_account_id     = data.aws_caller_identity.current.account_id
   availability_zones = ["us-east-2a"]
   properties = {

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/output.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/output.tf
@@ -1,15 +1,15 @@
-output oidc_config_id {
-  value =  ocm_rosa_oidc_config.oidc_config.id
+output "oidc_config_id" {
+  value = ocm_rosa_oidc_config.oidc_config.id
 }
 
-output oidc_endpoint_url{
+output "oidc_endpoint_url" {
   value = ocm_rosa_oidc_config.oidc_config.oidc_endpoint_url
 }
 
-output thumbprint{
+output "thumbprint" {
   value = ocm_rosa_oidc_config.oidc_config.thumbprint
 }
 
-output cluster_id {
+output "cluster_id" {
   value = ocm_cluster_rosa_classic.rosa_sts_cluster.id
 }

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/variables.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/variables.tf
@@ -1,18 +1,18 @@
-variable token {
-  type = string
+variable "token" {
+  type      = string
   sensitive = true
 }
 
-variable url {
-    type = string
-    default = "https://api.openshift.com"
+variable "url" {
+  type    = string
+  default = "https://api.openshift.com"
 }
 
-variable operator_role_prefix {
-    type = string
+variable "operator_role_prefix" {
+  type = string
 }
 
-variable account_role_prefix {
-    type = string
-    default = ""
+variable "account_role_prefix" {
+  type    = string
+  default = ""
 }

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/variables.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/variables.tf
@@ -16,3 +16,18 @@ variable "account_role_prefix" {
   type    = string
   default = ""
 }
+
+variable "cluster_name" {
+  type    = string
+  default = "tf-gdb-test"
+}
+
+variable "cloud_region" {
+  type    = string
+  default = "us-east-2"
+}
+
+variable "availability_zones" {
+  type    = list(string)
+  default = ["us-east-2a"]
+}

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/main.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/main.tf
@@ -33,7 +33,7 @@ provider "ocm" {
 
 # Generates the OIDC config resources' names
 resource "ocm_rosa_oidc_config_input" "oidc_input" {
-  region = "us-east-2"
+  region = var.cloud_region
 }
 
 # Create the OIDC config resources on AWS
@@ -94,10 +94,10 @@ data "aws_caller_identity" "current" {
 }
 
 resource "ocm_cluster_rosa_classic" "rosa_sts_cluster" {
-  name               = "tf-gdb-test"
-  cloud_region       = "us-east-2"
+  name               = var.cluster_name
+  cloud_region       = var.cloud_region
   aws_account_id     = data.aws_caller_identity.current.account_id
-  availability_zones = ["us-east-2a"]
+  availability_zones = var.availability_zones
   properties = {
     rosa_creator_arn = data.aws_caller_identity.current.arn
   }

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/main.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/main.tf
@@ -28,7 +28,7 @@ terraform {
 }
 provider "ocm" {
   token = var.token
-  url = var.url
+  url   = var.url
 }
 
 # Generates the OIDC config resources' names
@@ -37,56 +37,56 @@ resource "ocm_rosa_oidc_config_input" "oidc_input" {
 }
 
 # Create the OIDC config resources on AWS
-module oidc_config_input_resources {
-  source = "terraform-redhat/rosa-sts/aws"
+module "oidc_config_input_resources" {
+  source  = "terraform-redhat/rosa-sts/aws"
   version = "0.0.5"
 
   create_oidc_config_resources = true
 
-  bucket_name = ocm_rosa_oidc_config_input.oidc_input.bucket_name
-  discovery_doc = ocm_rosa_oidc_config_input.oidc_input.discovery_doc
-  jwks = ocm_rosa_oidc_config_input.oidc_input.jwks
-  private_key = ocm_rosa_oidc_config_input.oidc_input.private_key
-  private_key_file_name = ocm_rosa_oidc_config_input.oidc_input.private_key_file_name
+  bucket_name             = ocm_rosa_oidc_config_input.oidc_input.bucket_name
+  discovery_doc           = ocm_rosa_oidc_config_input.oidc_input.discovery_doc
+  jwks                    = ocm_rosa_oidc_config_input.oidc_input.jwks
+  private_key             = ocm_rosa_oidc_config_input.oidc_input.private_key
+  private_key_file_name   = ocm_rosa_oidc_config_input.oidc_input.private_key_file_name
   private_key_secret_name = ocm_rosa_oidc_config_input.oidc_input.private_key_secret_name
 }
 
 # Create unmanaged OIDC config
 resource "ocm_rosa_oidc_config" "oidc_config" {
-  managed = false
-  secret_arn =  module.oidc_config_input_resources.secret_arn
-  issuer_url = ocm_rosa_oidc_config_input.oidc_input.issuer_url
+  managed            = false
+  secret_arn         = module.oidc_config_input_resources.secret_arn
+  issuer_url         = ocm_rosa_oidc_config_input.oidc_input.issuer_url
   installer_role_arn = var.installer_role_arn
 }
 
 data "ocm_rosa_operator_roles" "operator_roles" {
   operator_role_prefix = var.operator_role_prefix
-  account_role_prefix = var.account_role_prefix
+  account_role_prefix  = var.account_role_prefix
 }
 
-module operator_roles_and_oidc_provider {
-  source = "terraform-redhat/rosa-sts/aws"
+module "operator_roles_and_oidc_provider" {
+  source  = "terraform-redhat/rosa-sts/aws"
   version = ">=0.0.5"
 
   create_operator_roles = true
-  create_oidc_provider = true
+  create_oidc_provider  = true
 
-  cluster_id = ""
+  cluster_id                  = ""
   rh_oidc_provider_thumbprint = ocm_rosa_oidc_config.oidc_config.thumbprint
-  rh_oidc_provider_url = ocm_rosa_oidc_config.oidc_config.oidc_endpoint_url
-  operator_roles_properties = data.ocm_rosa_operator_roles.operator_roles.operator_iam_roles
+  rh_oidc_provider_url        = ocm_rosa_oidc_config.oidc_config.oidc_endpoint_url
+  operator_roles_properties   = data.ocm_rosa_operator_roles.operator_roles.operator_iam_roles
 }
 
 locals {
   sts_roles = {
-    role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-Installer-Role",
+    role_arn         = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-Installer-Role",
     support_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-Support-Role",
     instance_iam_roles = {
       master_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-ControlPlane-Role",
       worker_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-Worker-Role"
     },
     operator_role_prefix = var.operator_role_prefix,
-    oidc_config_id = ocm_rosa_oidc_config.oidc_config.id
+    oidc_config_id       = ocm_rosa_oidc_config.oidc_config.id
   }
 }
 
@@ -94,8 +94,8 @@ data "aws_caller_identity" "current" {
 }
 
 resource "ocm_cluster_rosa_classic" "rosa_sts_cluster" {
-  name           = "tf-gdb-test"
-  cloud_region   = "us-east-2"
+  name               = "tf-gdb-test"
+  cloud_region       = "us-east-2"
   aws_account_id     = data.aws_caller_identity.current.account_id
   availability_zones = ["us-east-2a"]
   properties = {

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/output.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/output.tf
@@ -1,15 +1,15 @@
-output oidc_config_id {
-  value =  ocm_rosa_oidc_config.oidc_config.id
+output "oidc_config_id" {
+  value = ocm_rosa_oidc_config.oidc_config.id
 }
 
-output oidc_endpoint_url{
+output "oidc_endpoint_url" {
   value = ocm_rosa_oidc_config.oidc_config.oidc_endpoint_url
 }
 
-output thumbprint{
+output "thumbprint" {
   value = ocm_rosa_oidc_config.oidc_config.thumbprint
 }
 
-output cluster_id {
+output "cluster_id" {
   value = ocm_cluster_rosa_classic.rosa_sts_cluster.id
 }

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/variables.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/variables.tf
@@ -21,3 +21,18 @@ variable "installer_role_arn" {
   type    = string
   default = ""
 }
+
+variable "cluster_name" {
+  type    = string
+  default = "tf-gdb-test"
+}
+
+variable "cloud_region" {
+  type    = string
+  default = "us-east-2"
+}
+
+variable "availability_zones" {
+  type    = list(string)
+  default = ["us-east-2a"]
+}

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/variables.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/variables.tf
@@ -1,23 +1,23 @@
-variable token {
-  type = string
+variable "token" {
+  type      = string
   sensitive = true
 }
 
-variable url {
-    type = string
-    default = "https://api.openshift.com"
+variable "url" {
+  type    = string
+  default = "https://api.openshift.com"
 }
 
-variable operator_role_prefix {
-    type = string
+variable "operator_role_prefix" {
+  type = string
 }
 
-variable account_role_prefix {
-    type = string
-    default = ""
+variable "account_role_prefix" {
+  type    = string
+  default = ""
 }
 
-variable installer_role_arn {
-    type = string
-    default = ""
+variable "installer_role_arn" {
+  type    = string
+  default = ""
 }


### PR DESCRIPTION
In order to let the user control on the resources names and region, change those parameters to variables for managed and unmanaged clusters

Please notice: First commit is "make fmt_tf" auto results