### PR TITLE
Examples: Move OIDC provider creation to different module

### DIFF
--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/main.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/main.tf
@@ -31,26 +31,14 @@ provider "ocm" {
   url   = var.url
 }
 
-resource "ocm_rosa_oidc_config" "oidc_config" {
-  managed = true
-}
-
-data "ocm_rosa_operator_roles" "operator_roles" {
+# Create managed OIDC config
+module "oidc_config" {
+  token                = var.token
+  url                  = var.url
+  source               = "../oidc_provider"
+  managed              = true
   operator_role_prefix = var.operator_role_prefix
   account_role_prefix  = var.account_role_prefix
-}
-
-module "operator_roles_and_oidc_provider" {
-  source  = "terraform-redhat/rosa-sts/aws"
-  version = ">=0.0.5"
-
-  create_operator_roles = true
-  create_oidc_provider  = true
-
-  cluster_id                  = ""
-  rh_oidc_provider_thumbprint = ocm_rosa_oidc_config.oidc_config.thumbprint
-  rh_oidc_provider_url        = ocm_rosa_oidc_config.oidc_config.oidc_endpoint_url
-  operator_roles_properties   = data.ocm_rosa_operator_roles.operator_roles.operator_iam_roles
 }
 
 locals {
@@ -62,7 +50,7 @@ locals {
       worker_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-Worker-Role"
     },
     operator_role_prefix = var.operator_role_prefix,
-    oidc_config_id       = ocm_rosa_oidc_config.oidc_config.id
+    oidc_config_id       = module.oidc_config.id
   }
 }
 

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/output.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/output.tf
@@ -1,13 +1,13 @@
 output "oidc_config_id" {
-  value = ocm_rosa_oidc_config.oidc_config.id
+  value = module.oidc_config.id
 }
 
 output "oidc_endpoint_url" {
-  value = ocm_rosa_oidc_config.oidc_config.oidc_endpoint_url
+  value = module.oidc_config.oidc_endpoint_url
 }
 
 output "thumbprint" {
-  value = ocm_rosa_oidc_config.oidc_config.thumbprint
+  value = module.oidc_config.thumbprint
 }
 
 output "cluster_id" {

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/main.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/main.tf
@@ -31,50 +31,16 @@ provider "ocm" {
   url   = var.url
 }
 
-# Generates the OIDC config resources' names
-resource "ocm_rosa_oidc_config_input" "oidc_input" {
-  region = var.cloud_region
-}
-
-# Create the OIDC config resources on AWS
-module "oidc_config_input_resources" {
-  source  = "terraform-redhat/rosa-sts/aws"
-  version = "0.0.5"
-
-  create_oidc_config_resources = true
-
-  bucket_name             = ocm_rosa_oidc_config_input.oidc_input.bucket_name
-  discovery_doc           = ocm_rosa_oidc_config_input.oidc_input.discovery_doc
-  jwks                    = ocm_rosa_oidc_config_input.oidc_input.jwks
-  private_key             = ocm_rosa_oidc_config_input.oidc_input.private_key
-  private_key_file_name   = ocm_rosa_oidc_config_input.oidc_input.private_key_file_name
-  private_key_secret_name = ocm_rosa_oidc_config_input.oidc_input.private_key_secret_name
-}
-
 # Create unmanaged OIDC config
-resource "ocm_rosa_oidc_config" "oidc_config" {
-  managed            = false
-  secret_arn         = module.oidc_config_input_resources.secret_arn
-  issuer_url         = ocm_rosa_oidc_config_input.oidc_input.issuer_url
-  installer_role_arn = var.installer_role_arn
-}
-
-data "ocm_rosa_operator_roles" "operator_roles" {
+module "oidc_config" {
+  token                = var.token
+  url                  = var.url
+  source               = "../oidc_provider"
+  managed              = false
+  installer_role_arn   = var.installer_role_arn
   operator_role_prefix = var.operator_role_prefix
   account_role_prefix  = var.account_role_prefix
-}
-
-module "operator_roles_and_oidc_provider" {
-  source  = "terraform-redhat/rosa-sts/aws"
-  version = ">=0.0.5"
-
-  create_operator_roles = true
-  create_oidc_provider  = true
-
-  cluster_id                  = ""
-  rh_oidc_provider_thumbprint = ocm_rosa_oidc_config.oidc_config.thumbprint
-  rh_oidc_provider_url        = ocm_rosa_oidc_config.oidc_config.oidc_endpoint_url
-  operator_roles_properties   = data.ocm_rosa_operator_roles.operator_roles.operator_iam_roles
+  cloud_region         = var.cloud_region
 }
 
 locals {
@@ -86,7 +52,7 @@ locals {
       worker_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-Worker-Role"
     },
     operator_role_prefix = var.operator_role_prefix,
-    oidc_config_id       = ocm_rosa_oidc_config.oidc_config.id
+    oidc_config_id       = module.oidc_config.id
   }
 }
 

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/output.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/output.tf
@@ -1,13 +1,13 @@
 output "oidc_config_id" {
-  value = ocm_rosa_oidc_config.oidc_config.id
+  value = module.oidc_config.id
 }
 
 output "oidc_endpoint_url" {
-  value = ocm_rosa_oidc_config.oidc_config.oidc_endpoint_url
+  value = module.oidc_config.oidc_endpoint_url
 }
 
 output "thumbprint" {
-  value = ocm_rosa_oidc_config.oidc_config.thumbprint
+  value = module.oidc_config.thumbprint
 }
 
 output "cluster_id" {

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/oidc_provider/README.md
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/oidc_provider/README.md
@@ -1,0 +1,54 @@
+# OIDC provider creation example
+
+This example shows how to create an OIDC config, an operator IAM roles and an OIDC provider.
+
+In order to create unmanaged OIDC config you'll need to create those resources: 
+1. OIDC config input - using the resource called `ocm_rosa_oidc_config_input`
+2. AWS resources - using the module that celled `oidc_config_input_resources` in the main.tf file
+3. OIDC config = using the resource `ocm_rosa_oidc_config`
+
+After you created the OIDC config you can create the OIDC provider and operator roles.
+
+To run it:
+
+* Provide OCM Authentication Token
+
+  OCM authentication token that you can get [here](https://console.redhat.com/openshift/token).
+
+    ```
+    export TF_VAR_token=...
+    ```
+
+* Provide OCM environment by setting a value to url
+
+    ```
+    export TF_VAR_url=...
+    ```
+* Indicate weather this is managed or unmanaged provider config
+
+    ```
+    export TF_VAR_managed=[true/false]
+    ```
+* For unmanaged provider config, provide Installer Role ARN by setting a value 
+
+    ```
+    export TF_VAR_installer_role_arn=...
+    ```
+
+* Decide STS operator_role_prefix
+
+    ```
+    export TF_VAR_operator_role_prefix=...
+    ```
+
+* Decide STS account_role_prefix. if not set use the default account IAM roles
+
+    ```
+    export TF_VAR_account_role_prefix=...
+    ```
+* You can decide which cloud region to use, this is optional, default us-east-2
+    ```
+    export TF_VAR_cloud_region=...
+    ```
+
+and then run the `terraform apply` command.

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/oidc_provider/main.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/oidc_provider/main.tf
@@ -1,0 +1,81 @@
+#
+# Copyright (c) 2023 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.20.0"
+    }
+    ocm = {
+      version = ">=1.0.1"
+      source  = "terraform-redhat/ocm"
+    }
+  }
+}
+provider "ocm" {
+  token = var.token
+  url   = var.url
+}
+
+# Generates the OIDC config resources' names
+resource "ocm_rosa_oidc_config_input" "oidc_input" {
+  count = var.managed ? 0 : 1
+
+  region = var.cloud_region
+}
+
+# Create the OIDC config resources on AWS
+module "oidc_config_input_resources" {
+  count = var.managed ? 0 : 1
+
+  source  = "terraform-redhat/rosa-sts/aws"
+  version = "0.0.5"
+
+  create_oidc_config_resources = true
+
+  bucket_name             = one(ocm_rosa_oidc_config_input.oidc_input[*].bucket_name)
+  discovery_doc           = one(ocm_rosa_oidc_config_input.oidc_input[*].discovery_doc)
+  jwks                    = one(ocm_rosa_oidc_config_input.oidc_input[*].jwks)
+  private_key             = one(ocm_rosa_oidc_config_input.oidc_input[*].private_key)
+  private_key_file_name   = one(ocm_rosa_oidc_config_input.oidc_input[*].private_key_file_name)
+  private_key_secret_name = one(ocm_rosa_oidc_config_input.oidc_input[*].private_key_secret_name)
+}
+
+resource "ocm_rosa_oidc_config" "oidc_config" {
+  managed            = var.managed
+  secret_arn         = one(module.oidc_config_input_resources[*].secret_arn)
+  issuer_url         = one(ocm_rosa_oidc_config_input.oidc_input[*].issuer_url)
+  installer_role_arn = var.installer_role_arn
+}
+
+data "ocm_rosa_operator_roles" "operator_roles" {
+  operator_role_prefix = var.operator_role_prefix
+  account_role_prefix  = var.account_role_prefix
+}
+
+module "operator_roles_and_oidc_provider" {
+  source  = "terraform-redhat/rosa-sts/aws"
+  version = ">=0.0.5"
+
+  create_operator_roles = true
+  create_oidc_provider  = true
+
+  cluster_id                  = ""
+  rh_oidc_provider_thumbprint = ocm_rosa_oidc_config.oidc_config.thumbprint
+  rh_oidc_provider_url        = ocm_rosa_oidc_config.oidc_config.oidc_endpoint_url
+  operator_roles_properties   = data.ocm_rosa_operator_roles.operator_roles.operator_iam_roles
+}

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/oidc_provider/output.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/oidc_provider/output.tf
@@ -1,0 +1,11 @@
+output "id" {
+  value = ocm_rosa_oidc_config.oidc_config.id
+}
+
+output "oidc_endpoint_url" {
+  value = ocm_rosa_oidc_config.oidc_config.oidc_endpoint_url
+}
+
+output "thumbprint" {
+  value = ocm_rosa_oidc_config.oidc_config.thumbprint
+}

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/oidc_provider/variables.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/oidc_provider/variables.tf
@@ -1,0 +1,34 @@
+variable "token" {
+  type      = string
+  sensitive = true
+}
+
+variable "url" {
+  type    = string
+  default = "https://api.openshift.com"
+}
+
+variable "managed" {
+  description = "Indicates whether it is a Red Hat managed or unmanaged (Customer hosted) OIDC Configuration"
+  type        = bool
+}
+
+variable "installer_role_arn" {
+  description = "STS Role ARN with get secrets permission, relevant only for unmanaged OIDC config"
+  type        = string
+  default     = null
+}
+
+variable "operator_role_prefix" {
+  type = string
+}
+
+variable "account_role_prefix" {
+  type    = string
+  default = ""
+}
+
+variable "cloud_region" {
+  type    = string
+  default = "us-east-2"
+}


### PR DESCRIPTION
Move OIDC provider creation to different directory, in order to give the user template how to run it, out of the cluster context This also include the OIDC config (relevant only for unmanaged scenario) and the operator IAM roles The managed and unmanaged cluster use this as module, but now user can easily remove this part from the cluster creation