### PR TITLE
OCM-2237: Add support for adding path to account roles in creation

### DIFF
--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/account_roles/README.md
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/account_roles/README.md
@@ -30,5 +30,10 @@ To run it:
     export TF_VAR_url=...
     ```
 
+* Provide STS account_role_path (optional):
+    ```
+    export TF_VAR_account_role_path=...
+    ```
+
 and then run the `terraform apply` command.
 

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/account_roles/main.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/account_roles/main.tf
@@ -36,7 +36,7 @@ data "ocm_policies" "all_policies" {}
 
 module "create_account_roles" {
   source  = "terraform-redhat/rosa-sts/aws"
-  version = ">=0.0.5"
+  version = ">=0.0.6"
 
   create_operator_roles = false
   create_oidc_provider  = false
@@ -47,4 +47,5 @@ module "create_account_roles" {
   rosa_openshift_version = var.openshift_version
   account_role_policies  = data.ocm_policies.all_policies.account_role_policies
   operator_role_policies = data.ocm_policies.all_policies.operator_role_policies
+  account_role_path      = var.account_role_path
 }

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/account_roles/variables.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/account_roles/variables.tf
@@ -19,3 +19,9 @@ variable "token" {
 variable "url" {
   type = string
 }
+
+variable "account_role_path" {
+  description = "(Optional) Path to the account role."
+  type        = string
+  default     = null
+}

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/README.md
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/README.md
@@ -30,4 +30,9 @@ To run it:
     export TF_VAR_account_role_prefix=...
     ```
 
+* Provide STS account_role_path (optional):
+    ```
+    export TF_VAR_account_role_path=...
+    ```
+
 and then run the `terraform apply` command.

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/main.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/main.tf
@@ -43,11 +43,11 @@ module "oidc_config" {
 
 locals {
   sts_roles = {
-    role_arn         = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-Installer-Role",
-    support_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-Support-Role",
+    role_arn         = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${var.account_role_path}${var.account_role_prefix}-Installer-Role",
+    support_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${var.account_role_path}${var.account_role_prefix}-Support-Role",
     instance_iam_roles = {
-      master_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-ControlPlane-Role",
-      worker_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-Worker-Role"
+      master_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${var.account_role_path}${var.account_role_prefix}-ControlPlane-Role",
+      worker_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${var.account_role_path}${var.account_role_prefix}-Worker-Role"
     },
     operator_role_prefix = var.operator_role_prefix,
     oidc_config_id       = module.oidc_config.id

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/variables.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/variables.tf
@@ -31,3 +31,9 @@ variable "availability_zones" {
   type    = list(string)
   default = ["us-east-2a"]
 }
+
+variable "account_role_path" {
+  description = "(Optional) Path to the account role."
+  type        = string
+  default     = "/"
+}

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/README.md
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/README.md
@@ -41,4 +41,9 @@ To run it:
     export TF_VAR_account_role_prefix=...
     ```
 
+* Provide STS account_role_path (optional):
+    ```
+    export TF_VAR_account_role_path=...
+    ```
+
 and then run the `terraform apply` command.

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/main.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/main.tf
@@ -45,11 +45,11 @@ module "oidc_config" {
 
 locals {
   sts_roles = {
-    role_arn         = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-Installer-Role",
-    support_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-Support-Role",
+    role_arn         = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${var.account_role_path}${var.account_role_prefix}-Installer-Role",
+    support_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${var.account_role_path}${var.account_role_prefix}-Support-Role",
     instance_iam_roles = {
-      master_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-ControlPlane-Role",
-      worker_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-Worker-Role"
+      master_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${var.account_role_path}${var.account_role_prefix}-ControlPlane-Role",
+      worker_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${var.account_role_path}${var.account_role_prefix}-Worker-Role"
     },
     operator_role_prefix = var.operator_role_prefix,
     oidc_config_id       = module.oidc_config.id

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/variables.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/variables.tf
@@ -36,3 +36,9 @@ variable "availability_zones" {
   type    = list(string)
   default = ["us-east-2a"]
 }
+
+variable "account_role_path" {
+  description = "(Optional) Path to the account role."
+  type        = string
+  default     = "/"
+}

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/oidc_provider/main.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/oidc_provider/main.tf
@@ -69,7 +69,7 @@ data "ocm_rosa_operator_roles" "operator_roles" {
 
 module "operator_roles_and_oidc_provider" {
   source  = "terraform-redhat/rosa-sts/aws"
-  version = ">=0.0.5"
+  version = ">=0.0.6"
 
   create_operator_roles = true
   create_oidc_provider  = true


### PR DESCRIPTION
Also added option to seth the path in the managed and unmanaged clusters in order to allow using it from the clusters