### PR TITLE
OCM-2289: Add the option for tagging AWS resources in the example files

### DIFF
--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/account_roles/README.md
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/account_roles/README.md
@@ -35,5 +35,10 @@ To run it:
     export TF_VAR_account_role_path=...
     ```
 
+* Provide List of AWS resource tags to apply (optional):
+    ```
+    export TF_VAR_tags=...
+    ```
+
 and then run the `terraform apply` command.
 

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/account_roles/main.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/account_roles/main.tf
@@ -48,4 +48,5 @@ module "create_account_roles" {
   account_role_policies  = data.ocm_policies.all_policies.account_role_policies
   operator_role_policies = data.ocm_policies.all_policies.operator_role_policies
   account_role_path      = var.account_role_path
+  tags                   = var.tags
 }

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/account_roles/variables.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/account_roles/variables.tf
@@ -25,3 +25,10 @@ variable "account_role_path" {
   type        = string
   default     = null
 }
+
+variable "tags" {
+  description = "List of AWS resource tags to apply."
+  type        = map(string)
+  default     = null
+}
+

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/cluster/README.md
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/cluster/README.md
@@ -27,5 +27,11 @@ To run it:
     ```
     export TF_VAR_account_role_prefix=...
     ```
+
+* Provide List of AWS resource tags to apply (optional):
+    ```
+    export TF_VAR_tags=...
+    ```
+
 and then run the `terraform apply` command.
 

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/cluster/main.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/cluster/main.tf
@@ -84,5 +84,6 @@ module "operator_roles" {
   rh_oidc_provider_thumbprint = ocm_cluster_rosa_classic.rosa_sts_cluster.sts.thumbprint
   rh_oidc_provider_url        = ocm_cluster_rosa_classic.rosa_sts_cluster.sts.oidc_endpoint_url
   operator_roles_properties   = data.ocm_rosa_operator_roles.operator_roles.operator_iam_roles
+  tags                        = var.tags
 }
 

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/cluster/variables.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/cluster/variables.tf
@@ -30,3 +30,9 @@ variable "availability_zones" {
   type    = list(string)
   default = ["us-east-2a"]
 }
+
+variable "tags" {
+  description = "List of AWS resource tags to apply."
+  type        = map(string)
+  default     = null
+}

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/README.md
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/README.md
@@ -35,4 +35,9 @@ To run it:
     export TF_VAR_account_role_path=...
     ```
 
+* Provide List of AWS resource tags to apply (optional):
+    ```
+    export TF_VAR_tags=...
+    ``
+
 and then run the `terraform apply` command.

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/main.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/main.tf
@@ -39,6 +39,7 @@ module "oidc_config" {
   managed              = true
   operator_role_prefix = var.operator_role_prefix
   account_role_prefix  = var.account_role_prefix
+  tags                 = var.tags
 }
 
 locals {

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/variables.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/variables.tf
@@ -37,3 +37,10 @@ variable "account_role_path" {
   type        = string
   default     = "/"
 }
+
+variable "tags" {
+  description = "List of AWS resource tags to apply."
+  type        = map(string)
+  default     = null
+}
+

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/README.md
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/README.md
@@ -46,4 +46,9 @@ To run it:
     export TF_VAR_account_role_path=...
     ```
 
+* Provide List of AWS resource tags to apply (optional):
+    ```
+    export TF_VAR_tags=...
+    ``
+
 and then run the `terraform apply` command.

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/main.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/main.tf
@@ -41,6 +41,7 @@ module "oidc_config" {
   operator_role_prefix = var.operator_role_prefix
   account_role_prefix  = var.account_role_prefix
   cloud_region         = var.cloud_region
+  tags                 = var.tags
 }
 
 locals {

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/variables.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/variables.tf
@@ -42,3 +42,9 @@ variable "account_role_path" {
   type        = string
   default     = "/"
 }
+
+variable "tags" {
+  description = "List of AWS resource tags to apply."
+  type        = map(string)
+  default     = null
+}

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/oidc_provider/README.md
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/oidc_provider/README.md
@@ -51,4 +51,9 @@ To run it:
     export TF_VAR_cloud_region=...
     ```
 
+* Provide List of AWS resource tags to apply (optional):
+    ```
+    export TF_VAR_tags=...
+    ```
+
 and then run the `terraform apply` command.

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/oidc_provider/main.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/oidc_provider/main.tf
@@ -78,4 +78,5 @@ module "operator_roles_and_oidc_provider" {
   rh_oidc_provider_thumbprint = ocm_rosa_oidc_config.oidc_config.thumbprint
   rh_oidc_provider_url        = ocm_rosa_oidc_config.oidc_config.oidc_endpoint_url
   operator_roles_properties   = data.ocm_rosa_operator_roles.operator_roles.operator_iam_roles
+  tags                        = var.tags
 }

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/oidc_provider/variables.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/oidc_provider/variables.tf
@@ -32,3 +32,9 @@ variable "cloud_region" {
   type    = string
   default = "us-east-2"
 }
+
+variable "tags" {
+  description = "List of AWS resource tags to apply."
+  type        = map(string)
+  default     = null
+}


### PR DESCRIPTION
Describing in the example files how to tag AWS resources using the variable 'tag'

 