### PR TITLE
OCM-2408: Improve upgrade agreements acknowlegement process

### DIFF
--- a/provider/cluster_rosa_classic_state.go
+++ b/provider/cluster_rosa_classic_state.go
@@ -61,6 +61,7 @@ type ClusterRosaClassicState struct {
 	DisableWaitingInDestroy   types.Bool   `tfsdk:"disable_waiting_in_destroy"`
 	DestroyTimeout            types.Int64  `tfsdk:"destroy_timeout"`
 	Ec2MetadataHttpTokens     types.String `tfsdk:"ec2_metadata_http_tokens"`
+	UpgradeAdminAck           types.Bool   `tfsdk:"upgrade_admin_ack"`
 }
 
 type Sts struct {

--- a/provider/common/helpers.go
+++ b/provider/common/helpers.go
@@ -24,7 +24,9 @@ import (
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
 	"github.com/pkg/errors"
+	"github.com/zgalor/weberr"
 )
 
 const versionPrefix = "openshift-v"
@@ -134,4 +136,13 @@ func IsGreaterThanOrEqual(version1, version2 string) (bool, error) {
 		return false, err
 	}
 	return v1.GreaterThanOrEqual(v2), nil
+}
+
+func HandleErr(res *ocmerrors.Error, err error) error {
+	msg := res.Reason()
+	if msg == "" {
+		msg = err.Error()
+	}
+	errType := weberr.ErrorType(res.Status())
+	return errType.Set(errors.Errorf("%s", msg))
 }

--- a/provider/upgrade/cluster_upgrade.go
+++ b/provider/upgrade/cluster_upgrade.go
@@ -17,6 +17,7 @@ package upgrade
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -24,6 +25,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/terraform-redhat/terraform-provider-ocm/provider/common"
+	"github.com/zgalor/weberr"
 )
 
 // ClusterUpgrade bundles the description of the upgrade with its current state
@@ -159,4 +162,84 @@ func CheckAndCancelUpgrades(ctx context.Context, client *cmv1.ClustersClient, up
 		}
 	}
 	return correctUpgradePending, nil
+}
+
+func AckVersionGate(
+	gateAgreementsClient *cmv1.VersionGateAgreementsClient,
+	gateID string) error {
+	agreement, err := cmv1.NewVersionGateAgreement().
+		VersionGate(cmv1.NewVersionGate().ID(gateID)).
+		Build()
+	if err != nil {
+		return err
+	}
+	response, err := gateAgreementsClient.Add().Body(agreement).Send()
+	if err != nil {
+		return common.HandleErr(response.Error(), err)
+	}
+	return nil
+}
+
+func CheckMissingAgreements(version string,
+	clusterKey string, upgradePoliciesClient *cmv1.UpgradePoliciesClient) ([]string, string, error) {
+	upgradePolicyBuilder := cmv1.NewUpgradePolicy().
+		ScheduleType("manual").
+		Version(version)
+	upgradePolicy, err := upgradePolicyBuilder.Build()
+
+	// check if the cluster upgrade requires gate agreements
+	gates, err := getMissingGateAgreements(upgradePolicy, upgradePoliciesClient)
+	if err != nil {
+		return []string{}, "", fmt.Errorf("failed to check for missing gate agreements upgrade for "+
+			"cluster '%s': %v", clusterKey, err)
+	}
+	str := "\nMissing required acknowledgements to schedule upgrade." +
+		"\nRead the below description and acknowledge to proceed with upgrade." +
+		"\nDescription:"
+	counter := 1
+	var gateIDs []string
+	for _, gate := range gates {
+		if !gate.STSOnly() {
+			str = fmt.Sprintf("%s\n%d) %s\n", str, counter, gate.Description())
+
+			if gate.WarningMessage() != "" {
+				str = fmt.Sprintf("%s   Warning:     %s\n", str, gate.WarningMessage())
+			}
+			str = fmt.Sprintf("%s   URL:         %s\n", str, gate.DocumentationURL())
+			counter++
+			gateIDs = append(gateIDs, gate.ID())
+		}
+	}
+	return gateIDs, str, nil
+}
+
+func getMissingGateAgreements(
+	upgradePolicy *cmv1.UpgradePolicy,
+	upgradePoliciesClient *cmv1.UpgradePoliciesClient) ([]*cmv1.VersionGate, error) {
+	response, err := upgradePoliciesClient.Add().Parameter("dryRun", true).Body(upgradePolicy).Send()
+
+	if err != nil {
+		if response.Error() != nil {
+			// parse gates list
+			errorDetails, ok := response.Error().GetDetails()
+			if !ok {
+				return []*cmv1.VersionGate{}, common.HandleErr(response.Error(), err)
+			}
+			data, err := json.Marshal(errorDetails)
+			if err != nil {
+				return []*cmv1.VersionGate{}, common.HandleErr(response.Error(), err)
+			}
+			gates, err := cmv1.UnmarshalVersionGateList(data)
+			if err != nil {
+				return []*cmv1.VersionGate{}, common.HandleErr(response.Error(), err)
+			}
+			// return original error if invaild version gate detected
+			if len(gates) > 0 && gates[0].ID() == "" {
+				errType := weberr.ErrorType(response.Error().Status())
+				return []*cmv1.VersionGate{}, errType.Set(weberr.Errorf(response.Error().Reason()))
+			}
+			return gates, nil
+		}
+	}
+	return []*cmv1.VersionGate{}, nil
 }


### PR DESCRIPTION
* Add an option to approve - add boolean attribute "upgrade_admin_ack" (default=false)
* In case acknolege is missing, build elaborated description based on "upgradePoliciesClient" dry run

This is the error message displayed when try to update from 4.12.19 to 4.13.1 (candidate channel):
![image](https://github.com/terraform-redhat/terraform-provider-ocm/assets/38751082/d2f5283f-3659-4d44-86fa-55bdd7f48576)
