### PR TITLE
Day 2 Terraform Tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ The example Terraform files are all considered in development:
 1. [Create a ROSA cluster that usess STS and has a managed OIDC configuration](https://github.com/terraform-redhat/terraform-provider-ocm/blob/529b10c22c13810b3edbaa01327c7dfdcc207650/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/README.md)
 1. [Create a ROSA cluster that uses STS and has an unmanaged OIDC configuration](https://github.com/terraform-redhat/terraform-provider-ocm/blob/529b10c22c13810b3edbaa01327c7dfdcc207650/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/README.md)
 
+### Post cluster installation
+1. Modifying default machine pools
+1. [Identity provider](/examples/create_identity_provider/README.md). The following identity providers are supported:
+      * [Github](/examples/create_identity_provider/github/README.md)
+      * [Gitlab](/examples/create_identity_provider/gitlab/README.md)
+      * [HTPasswd](/examples/create_identity_provider/htpasswd/README.md)
+      * [Google](/examples/create_identity_provider/google/README.md)
+1. Update/Upgrade cluster
+
 ## Contributing to the Red Hat OCM Terraform Provider
 If you want to build a local OCM provider to develop improvements for the Red Hat OCM provider, you can run `terraform plan` against your local build with:
 1. Run  ```make install``` in the repository root directory. After running ```make install``` you will find the ocm provider binary file in the directory:

--- a/examples/create_identity_provider/README.md
+++ b/examples/create_identity_provider/README.md
@@ -1,0 +1,18 @@
+# Identity Provider for ROSA clusters
+
+The following pages show you how to configure various identity providers to use on your clusters. These identity providers offer ways for your users to log in to your cluster.
+
+## Prerequisites
+
+1. You created your [account roles using Terraform](../../examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/account_roles/README.md).
+1. You created your cluster using Terraform. This cluster can either have [a managed OIDC configuration](../../examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/README.md) or [an unmanaged OIDC configuration](../../examples/create_rosa_cluster/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/README.md).
+1. **Optional**: You have configured [your Terraform.tfvars file](../../docs/terraform-vars.md).
+
+## Types of identity providers
+
+The following identity providers are currently supported:
+
+1. [GitHub](../../examples/create_identity_provider/github/README.md)
+1. [Gitlab](../../examples/create_identity_provider/gitlab/README.md)
+1. [Google](../../examples/create_identity_provider/google/README.md)
+1. [HTPassword](../../examples/create_identity_provider/htpasswd/README.md)

--- a/examples/create_identity_provider/github/README.md
+++ b/examples/create_identity_provider/github/README.md
@@ -1,36 +1,26 @@
-# GitHub identity provider example
+# GitHub identity provider
 
 Configuring [GitHub authentication](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/authorizing-oauth-apps) allows users to log in to OpenShift Container Platform with their GitHub credentials.
-To prevent anyone with any GitHub user ID from logging in to your OpenShift Container Platform cluster, you can restrict access to only those in specific GitHub organizations.
 
+To prevent anyone with any GitHub user ID from logging in to your OpenShift Container Platform cluster, you can restrict access to only those in specific GitHub organizations.
 ## Prerequisites
 
-### An OpenShift cluster
+1. You created your [account roles using Terraform](../../examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/account_roles/README.md).
+1. You created your cluster using Terraform. This cluster can either have [a managed OIDC configuration](../../examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/README.md) or [an unmanaged OIDC configuration](../../examples/create_rosa_cluster/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/README.md).
+1. **Optional**: You have configured your Terraform.tfvars file.
 
-This example assumes you have created a cluster via OCM, It can be via this terraform provider or by a different client.
-We will need the cluster name and some credentials.
-
-### Setting up your application in GitHub
+## Setting up your application in GitHub
 
 To use GitHub or GitHub Enterprise as an identity provider, you must register an application to use.
 
-Procedure
-
 1. Register an application on GitHub:
-    
     - For GitHub, click [**Settings**](https://github.com/settings/profile) → [**Developer settings**](https://github.com/settings/apps) → [**OAuth Apps**](https://github.com/settings/developers) → [**Register a new OAuth application**](https://github.com/settings/applications/new).
-        
     - For GitHub Enterprise, go to your GitHub Enterprise home page and then click **Settings → Developer settings → Register a new application**.
-        
-    
 2. Enter an application name, for example `My OpenShift Install`.
-    
 3. Enter a homepage URL, such as `https://oauth-openshift.apps.<cluster-name>.<cluster-domain>`.
-    
-4. Optional: Enter an application description.
-    
+4. **Optional**: Enter an application description.    
 5. Enter the authorization callback URL, where the end of the URL contains the identity provider `name`:
-    
+
     `https://oauth-openshift.apps.<cluster-name>.<cluster-domain>/oauth2callback/<idp-provider-name>`
     
     For example:
@@ -40,17 +30,58 @@ Procedure
 
 6. Click **Register application**. GitHub provides a client ID and a client secret. You need these values to complete the identity provider configuration.
 
-## Execution
+## Applying the Terraform plan
 
-### Edit the terraform.tfvars
+1. You need to either edit the `terraform.tfvars` file within this directory, or add the following items to your existing `*.tfvars` file. You may also export these variables as environmental variables with the following commands:
+      1.  This value is the generated GitHub client secret to validate your account. It can be found in the settings of your GitHub account.
+          ```
+          export TF_VAR_github_client_secret=<github_client_secret>
+          ```
+      1.  This value is your GitHub client ID. It can be found in the settings of your GitHub account.   
+          ```
+          export TF_VAR_github_client_id=<client_id>
+          ```
+      1.  This value should be your GitHub organization. 
+          ```
+          export TF_VAR_github_orgs='["<github_org>"]'
+          ```
+      1.  This variable should be your full [OCM offline token](https://console.redhat.com/openshift/token) that you generated in the prerequisites.  
+          ```
+          export TF_VAR_token=<ocm_offline_token> 
+          ```
+      1.  This value should point to your OpenShift instance.  
+          ```
+          export TF_VAR_url=<ocm_url>
+          ```
+1. In your local copy of the `github` folder, run the following command:
+   ````
+   terraform init
+   ````
+   Running this command accesses all the necessary provider information to apply your Terraform plan.
+1. **Optional**: Run the `plan` command to ensure that your Terraform files build correctly without errors. This is not required to apply your Terraform plans.
+   ````
+   terraform plan -out github.tfplan
+   ````
+1. Run the apply command to create your GitHub identity provider. 
 
-Take your time with editing the variables file. 
-There are comments that will explain what each variable is.
+   > **Note**: If you did not run the `plan` command, you can simply just `apply` without specifying a file.
 
-### Let's Go!
+    ````
+    terraform apply <"github.tfplan">
+    ````
+1. The Terraform applies the plan and creates your identity provider using GitHub. You will see a prompt to confirm you want to create these resources. Enter `yes`, then the process will complete with your resources.
 
-Simply run `terraform apply`
+## Resource clean up
 
+After you are done with the resources you created, you should not delete them manually, but instead, use the `destroy` command. Run the following to delete all of your created resources:
+  
+```
+terraform destroy
+```
+
+After the command is complete, your resources are deleted.
+
+> **NOTE**: If you manually delete a resource, you create unresolvable issues within your environment.
 
 ## OpenShift documentation
 

--- a/examples/create_identity_provider/gitlab/README.md
+++ b/examples/create_identity_provider/gitlab/README.md
@@ -1,18 +1,16 @@
-# GitLab identity provider example
+# GitLab identity provider
 
 Configuring GitLab authentication allows users to log in to OpenShift Container Platform with their GitLab credentials.
 
 If you use GitLab version 7.7.0 to 11.0, you connect using the [OAuth integration](http://doc.gitlab.com/ce/integration/oauth_provider.html). If you use GitLab version 11.1 or later, you can use [OpenID Connect](https://docs.gitlab.com/ce/integration/openid_connect_provider.html) (OIDC) to connect instead of OAuth.
-This example shows how to create a Google identity provider.
 
 ## Prerequisites
 
-### An OpenShift cluster
+1. You created your [account roles using Terraform](../../examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/account_roles/README.md).
+1. You created your cluster using Terraform. This cluster can either have [a managed OIDC configuration](../../examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/README.md) or [an unmanaged OIDC configuration](../../examples/create_rosa_cluster/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/README.md).
+1. **Optional**: You have configured your Terraform.tfvars file.
 
-This example assumes you have created a cluster via OCM, It can be via this terraform provider or by a different client.
-We will need the cluster name and some credentials.
-
-### Setting up your application in GitLab
+## Setting up your application in GitLab
 
 You will need a client ID/Secret of a [registered GitLab OAuth application](https://docs.gitlab.com/ce/api/oauth2.html). 
 The application must be configured with a callback URL of `https://oauth-openshift.apps.<cluster-name>.<cluster-domain>/oauth2callback/<idp-provider-name>`
@@ -21,21 +19,61 @@ For example:
 
 > **Note**: `<idp-provider-name>` is case-sensitive. Name is defined [here](./main.tf#L37)
 
-## Execution
+## Applying the Terraform plan
 
-### Edit the terraform.tfvars
+1. You need to either edit the `terraform.tfvars` file within this directory, or add the following items to your existing `*.tfvars` file. You may also export these variables as environmental variables with the following commands:
+      1.  This value is the generated GitLab client secret to validate your account. It can be found in the settings of your GitLab account.
+          ```
+          export TF_VAR_gitlab_client_secret=<gitlab_client_secret>
+          ```
+      1.  This value is your GitLab client ID. It can be found in the settings of your GitLab account.   
+          ```
+          export TF_VAR_gitlab_client_id=<client_id>
+          ```
+      1.  This value should be your GitLab URL that was generated in the previous step.  
+          ```
+          export TF_VAR_gitlab_url='["<gitlab_url>"]'
+          ```
+      1.  This variable should be your full [OCM offline token](https://console.redhat.com/openshift/token) that you generated in the prerequisites.  
+          ```
+          export TF_VAR_token=<ocm_offline_token> 
+          ```
+      1.  This value should point to your OpenShift instance.  
+          ```
+          export TF_VAR_url=<ocm_url>
+          ```
+1. In your local copy of the `gitlab` folder, run the following command:
+   ````
+   terraform init
+   ````
+   Running this command accesses all the necessary provider information to apply your Terraform plan.
+1. **Optional**: Run the `plan` command to ensure that your Terraform files build correctly without errors. This is not required to apply your Terraform plans.
+   ````
+   terraform plan -out gitlab.tfplan
+   ````
+1. Run the apply command to create your GitLab identity provider. 
 
-Take your time with editing the variables file. 
-There are comments that will explain what each variable is.
+   > **Note**: If you did not run the `plan` command, you can simply just `apply` without specifying a file.
 
-### Let's Go!
+    ````
+    terraform apply <"gitlab.tfplan">
+    ````
+1. The Terraform applies the plan and creates your identity provider using GitLab. You will see a prompt to confirm you want to create these resources. Enter `yes`, then the process will complete with your resources.
 
-Simply run `terraform apply`
+## Resource clean up
 
+After you are done with the resources you created, you should not delete them manually, but instead, use the `destroy` command. Run the following to delete all of your created resources:
+  
+```
+terraform destroy
+```
+
+After the command is complete, your resources are deleted.
+
+> **NOTE**: If you manually delete a resource, you create unresolvable issues within your environment.
 
 ## OpenShift documentation
 
  - [GitLab Identity Provider](https://docs.openshift.com/container-platform/4.12/authentication/identity_providers/configuring-gitlab-identity-provider.html)
  - [Understanding identity provider configuration](https://docs.openshift.com/container-platform/4.12/authentication/understanding-identity-provider.html)
  - [Mapping Methods](https://docs.openshift.com/container-platform/4.12/authentication/understanding-identity-provider.html#identity-provider-parameters_understanding-identity-provider)
-

--- a/examples/create_identity_provider/google/README.md
+++ b/examples/create_identity_provider/google/README.md
@@ -1,18 +1,15 @@
-# Google identity provider example
+# Google identity provider
 
 Using Google as an identity provider allows any Google user to authenticate to your server.
 You can limit authentication to members of a specific hosted domain with the `hosted_domain` configuration attribute.
 
-This example shows how to create a Google identity provider.
-
 ## Prerequisites
 
-### An OpenShift cluster
+1. You created your [account roles using Terraform](../../examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/account_roles/README.md).
+1. You created your cluster using Terraform. This cluster can either have [a managed OIDC configuration](../../examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/README.md) or [an unmanaged OIDC configuration](../../examples/create_rosa_cluster/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/README.md).
+1. **Optional**: You have configured your Terraform.tfvars file.
 
-This example assumes you have created a cluster via OCM, It can be via this terraform provider or by a different client.
-We will need the cluster name and some credentials.
-
-### Setting up your application in Google
+## Setting up your application in Google
 
 You will need a client ID/Secret of a [registered Google project](https://console.developers.google.com/).
 The project must be configured with a redirect URI of `https://oauth-openshift.apps.<cluster-name>.<cluster-domain>/oauth2callback/<idp-provider-name>`.
@@ -21,17 +18,58 @@ For example:
 
 > **Note**: `<idp-provider-name>` is case-sensitive. Name is defined [here](./main.tf#L37)
 
-## Execution
+## Applying the Terraform plan
 
-### Edit the terraform.tfvars
+1. You need to either edit the `terraform.tfvars` file within this directory, or add the following items to your existing `*.tfvars` file. You may also export these variables as environmental variables with the following commands:
+      1.  This value is the generated Google client secret to validate your account. It can be found in the settings of your Google account.
+          ```
+          export TF_VAR_google_client_secret=<google_client_secret>
+          ```
+      1.  This value is your Google client ID. It can be found in the settings of your Google account.   
+          ```
+          export TF_VAR_google_client_id=<client_id>
+          ```
+      1.  This value should be your Google hosted domain that was generated in the previous step.  
+          ```
+          export TF_VAR_google_hosted_domain='["<google_hosted_domain>"]'
+          ```
+      1.  This variable should be your full [OCM offline token](https://console.redhat.com/openshift/token) that you generated in the prerequisites.  
+          ```
+          export TF_VAR_token=<ocm_offline_token> 
+          ```
+      1.  This value should point to your OpenShift instance.  
+          ```
+          export TF_VAR_url=<ocm_url>
+          ```
+1. In your local copy of the `google` folder, run the following command:
+   ````
+   terraform init
+   ````
+   Running this command accesses all the necessary provider information to apply your Terraform plan.
+1. **Optional**: Run the `plan` command to ensure that your Terraform files build correctly without errors. This is not required to apply your Terraform plans.
+   ````
+   terraform plan -out google.tfplan
+   ````
+1. Run the apply command to create your Google identity provider. 
 
-Take your time with editing the variables file. 
-There are comments that will explain what each variable is.
+   > **Note**: If you did not run the `plan` command, you can simply just `apply` without specifying a file.
 
-### Let's Go!
+    ````
+    terraform apply <"google.tfplan">
+    ````
+1. The Terraform applies the plan and creates your identity provider using Google. You will see a prompt to confirm you want to create these resources. Enter `yes`, then the process will complete with your resources.
 
-Simply run `terraform apply`
+## Resource clean up
 
+After you are done with the resources you created, you should not delete them manually, but instead, use the `destroy` command. Run the following to delete all of your created resources:
+  
+```
+terraform destroy
+```
+
+After the command is complete, your resources are deleted.
+
+> **NOTE**: If you manually delete a resource, you create unresolvable issues within your environment.
 
 ## OpenShift documentation
 

--- a/examples/create_identity_provider/htpasswd/README.md
+++ b/examples/create_identity_provider/htpasswd/README.md
@@ -1,24 +1,63 @@
-# htpasswd identity provider example
+# htpasswd identity provider
 
 Using htpasswd authentication in OpenShift Container Platform allows you to identify users based on username/password pairs.
+
+> **IMPORTANT**: htpasswd does not support multiple users.
+
 ## Prerequisites
 
-### An OpenShift cluster
+1. You created your [account roles using Terraform](../../examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/account_roles/README.md).
+1. You created your cluster using Terraform. This cluster can either have [a managed OIDC configuration](../../examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/README.md) or [an unmanaged OIDC configuration](../../examples/create_rosa_cluster/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/README.md).
+1. **Optional**: You have configured your Terraform.tfvars file.
 
-This example assumes you have created a cluster via OCM, It can be via this terraform provider or by a different client.
-We will need the cluster name and some credentials.
+## Applying the Terraform plan
 
-## Execution
+1. You need to either edit the `terraform.tfvars` file within this directory, or add the following items to your existing `*.tfvars` file. You may also export these variables as environmental variables with the following commands:
+      1.  This value sets the username for logging into your application.
+          ```
+          export TF_VAR_htpasswd_username=<user-name-to-login>
+          ```
+      1.  This value is the password for the account that you are creating.   
+          ```
+          export TF_VAR_htpasswd_password=<password-for-user-name>
+          ```
+      1.  This variable should be your full [OCM offline token](https://console.redhat.com/openshift/token) that you generated in the prerequisites.  
+          ```
+          export TF_VAR_token=<ocm_offline_token> 
+          ```
+      1.  This value should point to your OpenShift instance.  
+          ```
+          export TF_VAR_url=<ocm_url>
+          ```
+1. In your local copy of the `htpasswd` folder, run the following command:
+   ````
+   terraform init
+   ````
+   Running this command accesses all the necessary provider information to apply your Terraform plan.
+1. **Optional**: Run the `plan` command to ensure that your Terraform files build correctly without errors. This is not required to apply your Terraform plans.
+   ````
+   terraform plan -out htpasswd.tfplan
+   ````
+1. Run the apply command to create your htpasswd identity provider. 
 
-### Edit the terraform.tfvars
+   > **Note**: If you did not run the `plan` command, you can simply just `apply` without specifying a file.
 
-Take your time with editing the variables file. 
-There are comments that will explain what each variable is.
+    ````
+    terraform apply <"htpasswd.tfplan">
+    ````
+1. The Terraform applies the plan and creates your identity provider using htpasswd. You will see a prompt to confirm you want to create these resources. Enter `yes`, then the process will complete with your resources.
 
-### Let's Go!
+## Resource clean up
 
-Simply run `terraform apply`
+After you are done with the resources you created, you should not delete them manually, but instead, use the `destroy` command. Run the following to delete all of your created resources:
+  
+```
+terraform destroy
+```
 
+After the command is complete, your resources are deleted.
+
+> **NOTE**: If you manually delete a resource, you create unresolvable issues within your environment.
 
 ## OpenShift documentation
 

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/README.md
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/README.md
@@ -4,7 +4,7 @@ This Terraform example creates a ROSA STS cluster that uses a managed OIDC confi
 
 ## Prerequisites
 
-* You have an AWS account.
+* You have an AWS account. Your locally configured AWS credentials are used to access to AWS API for validation purposes.
 * You have installed the latest version ROSA CLI (`rosa`).
 * You must have an offline OCM token. This token can be generated in the [Red Hat Hybrid Cloud Console](https://console.redhat.com/openshift/token).
 * You have installed Terraform. See the [Hashicorp Terraform page](https://developer.hashicorp.com/terraform/downloads) for the latest version.
@@ -87,7 +87,9 @@ This Terraform example creates a ROSA STS cluster that uses a managed OIDC confi
 
 After you are done with the resources you created, you should not delete them manually, but instead, use the `destroy` command. Run the following to delete all of your created resources:
   
-    terraform destroy
+```
+terraform destroy
+```
 
 After the command is complete, your resources are deleted.
 

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/README.md
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/README.md
@@ -4,7 +4,7 @@ This Terraform example creates a ROSA STS cluster that uses an unmanaged OIDC co
 
 ## Prerequisites
 
-* You have an AWS account.
+* You have an AWS account. Your locally configured AWS credentials are used to access to AWS API for validation purposes.
 * You have installed the latest version ROSA CLI (`rosa`).
 * You must have an offline OCM token. This token can be generated in the [Red Hat Hybrid Cloud Console](https://console.redhat.com/openshift/token).
 * You have installed Terraform. See the [Hashicorp Terraform page](https://developer.hashicorp.com/terraform/downloads) for the latest version.


### PR DESCRIPTION
This PR collects all of the post-cluster creation tasks. Using [this Bug Hunt document](https://docs.google.com/document/d/1x9U35yyypt-vmXBibKgp80RixlOuIim_sTFi-3HaKxU/edit), I plan to cover the following actions:

**Pre cluster installation:**
* Create account roles

**Cluster installation (day 1):**
* Create Rosa classic cluster with managed OIDC
* Create Rosa classic cluster with unmanaged OIDC

**Post cluster installation (day 2):**
* Modify Default Machine Pool 
      * Change replica count
      * Change Auto Scaling - enable/disable
      * Change Labels
* Create Identity provider
    The following identity providers are supported:
      * Github
      * Gitlab
      * HTPasswd
      * Google
      * LDAP
      * OpenID
* Update/Upgrade cluster
