### PR TITLE
Remove acks_for variable added by mistake to example

### DIFF
--- a/docs/upgrading-cluster.md
+++ b/docs/upgrading-cluster.md
@@ -15,9 +15,9 @@ To upgrade your ROSA cluster to another version, export the following variable t
     ```
     export TF_VAR_openshift_version=<version_number>
     ```
-1. When upgrading from between major Y-Streams, you may need to provide an administrative acknowledgement that there are major changes for your cluster. For example, if you are upgrading from 4.11.43 to 4.12.21, you must use `4.12` as the value for this variable.
+1. If you choose to upgrade to a new version that necessitates approval, particularly when transitioning between major Y-Streams, you may be asked to provide administrative confirmation regarding significant modifications for your cluster. In such a scenario, during the initial upgrade attempt, you will receive an error message that provides guidance on the necessary changes. It is crucial to diligently follow those instructions and only acknowledge completion of the requirements by adding the "upgrade_acknowledgements_for" attribute to your resource, specifying the target version. For instance, if you are upgrading from 4.11.43 to 4.12.21, you should use '4.12' as the value for this variable.
     ```
-    export TF_VAR_acks_for = <version_acknowledgement>
+    upgrade_acknowledgements_for = <version_acknowledgement>
     ```
 1. Run `terraform apply` to upgrade your cluster.
 

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/main.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/main.tf
@@ -63,13 +63,11 @@ resource "ocm_cluster_rosa_classic" "rosa_sts_cluster" {
   cloud_region       = var.cloud_region
   aws_account_id     = data.aws_caller_identity.current.account_id
   availability_zones = var.availability_zones
-  version            = "openshift-v${var.openshift_version}"
+  version            = var.openshift_version
   properties = {
     rosa_creator_arn = data.aws_caller_identity.current.arn
   }
   sts = local.sts_roles
-
-  upgrade_acknowledgements_for = var.acks_for
 }
 
 resource "ocm_cluster_wait" "rosa_cluster" {

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/variables.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/variables.tf
@@ -49,9 +49,3 @@ variable "openshift_version" {
   type        = string
   default     = "4.13.0"
 }
-
-variable "acks_for" {
-  description = "This variable is used to acknowledge significant changes between versions of OpenShift when performing a version upgrade.The acks_for variable must match the upgraded version's Y-stream."
-  type        = string
-  default     = null
-}


### PR DESCRIPTION
This was introduced in https://github.com/terraform-redhat/terraform-provider-ocm/pull/136 This variable shouldn't be used