### PR TITLE
Fix examples to use specific version of the module

### DIFF
--- a/ci/e2e/account_roles_files/main.tf
+++ b/ci/e2e/account_roles_files/main.tf
@@ -13,18 +13,18 @@ terraform {
 
 provider "ocm" {
   token = var.token
-  url = var.url
+  url   = var.url
 }
 
-data "ocm_policies" "all_policies"{}
+data "ocm_policies" "all_policies" {}
 
-module "create_account_roles"{
-  source = "terraform-redhat/rosa-sts/aws"
-  version = "0.0.4"
+module "create_account_roles" {
+  source  = "terraform-redhat/rosa-sts/aws"
+  version = "0.0.8"
 
   create_operator_roles = false
-  create_oidc_provider = false
-  create_account_roles = true
+  create_oidc_provider  = false
+  create_account_roles  = true
 
   account_role_prefix    = var.account_role_prefix
   ocm_environment        = var.ocm_environment

--- a/ci/e2e/oidc_configuration/cluster_with_managed_oidc_config/main.tf
+++ b/ci/e2e/oidc_configuration/cluster_with_managed_oidc_config/main.tf
@@ -42,7 +42,7 @@ data "ocm_rosa_operator_roles" "operator_roles" {
 
 module "operator_roles_and_oidc_provider" {
   source  = "terraform-redhat/rosa-sts/aws"
-  version = ">=0.0.5"
+  version = "0.0.8"
 
   create_operator_roles = true
   create_oidc_provider  = true

--- a/ci/e2e/oidc_configuration/cluster_with_unmanaged_oidc_config/main.tf
+++ b/ci/e2e/oidc_configuration/cluster_with_unmanaged_oidc_config/main.tf
@@ -39,7 +39,7 @@ resource "ocm_rosa_oidc_config_input" "oidc_input" {
 # Create the OIDC config resources on AWS
 module "oidc_config_input_resources" {
   source  = "terraform-redhat/rosa-sts/aws"
-  version = ">=0.0.5"
+  version = "0.0.8"
 
   create_oidc_config_resources = true
 
@@ -66,7 +66,7 @@ data "ocm_rosa_operator_roles" "operator_roles" {
 
 module "operator_roles_and_oidc_provider" {
   source  = "terraform-redhat/rosa-sts/aws"
-  version = "0.0.5"
+  version = "0.0.8"
 
   create_operator_roles = true
   create_oidc_provider  = true

--- a/ci/e2e/terraform_provider_ocm_files/main.tf
+++ b/ci/e2e/terraform_provider_ocm_files/main.tf
@@ -13,12 +13,12 @@ terraform {
 
 provider "ocm" {
   token = var.token
-  url = var.url
+  url   = var.url
 }
 
 locals {
   sts_roles = {
-    role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-Installer-Role",
+    role_arn         = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-Installer-Role",
     support_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-Support-Role",
     instance_iam_roles = {
       master_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-ControlPlane-Role",
@@ -41,9 +41,9 @@ resource "ocm_cluster_rosa_classic" "rosa_sts_cluster" {
   properties = {
     rosa_creator_arn = data.aws_caller_identity.current.arn
   }
-  sts                = local.sts_roles
-  replicas           = var.replicas
-  destroy_timeout    = 120
+  sts             = local.sts_roles
+  replicas        = var.replicas
+  destroy_timeout = 120
 }
 
 resource "ocm_cluster_wait" "rosa_cluster" {
@@ -53,19 +53,19 @@ resource "ocm_cluster_wait" "rosa_cluster" {
 
 data "ocm_rosa_operator_roles" "operator_roles" {
   operator_role_prefix = var.operator_role_prefix
-  account_role_prefix = var.account_role_prefix
+  account_role_prefix  = var.account_role_prefix
 }
 
-module operator_roles {
-  source = "terraform-redhat/rosa-sts/aws"
+module "operator_roles" {
+  source  = "terraform-redhat/rosa-sts/aws"
   version = ">=0.0.5"
 
   create_operator_roles = true
-  create_oidc_provider = true
-  create_account_roles = false
+  create_oidc_provider  = true
+  create_account_roles  = false
 
-  cluster_id = ocm_cluster_rosa_classic.rosa_sts_cluster.id
+  cluster_id                  = ocm_cluster_rosa_classic.rosa_sts_cluster.id
   rh_oidc_provider_thumbprint = ocm_cluster_rosa_classic.rosa_sts_cluster.sts.thumbprint
-  rh_oidc_provider_url = ocm_cluster_rosa_classic.rosa_sts_cluster.sts.oidc_endpoint_url
-  operator_roles_properties = data.ocm_rosa_operator_roles.operator_roles.operator_iam_roles
+  rh_oidc_provider_url        = ocm_cluster_rosa_classic.rosa_sts_cluster.sts.oidc_endpoint_url
+  operator_roles_properties   = data.ocm_rosa_operator_roles.operator_roles.operator_iam_roles
 }

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/account_roles/main.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/classic_sts/account_roles/main.tf
@@ -36,7 +36,7 @@ data "ocm_policies" "all_policies" {}
 
 module "create_account_roles" {
   source  = "terraform-redhat/rosa-sts/aws"
-  version = ">=0.0.8"
+  version = "0.0.8"
 
   create_operator_roles = false
   create_oidc_provider  = false

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/oidc_provider/main.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/oidc_provider/main.tf
@@ -47,7 +47,7 @@ module "oidc_config_input_resources" {
   count = var.managed ? 0 : 1
 
   source  = "terraform-redhat/rosa-sts/aws"
-  version = ">=0.0.8"
+  version = "0.0.8"
 
   create_oidc_config_resources = true
 
@@ -73,7 +73,7 @@ data "ocm_rosa_operator_roles" "operator_roles" {
 
 module "operator_roles_and_oidc_provider" {
   source  = "terraform-redhat/rosa-sts/aws"
-  version = ">=0.0.8"
+  version = "0.0.8"
 
   create_operator_roles = true
   create_oidc_provider  = true


### PR DESCRIPTION
When indicating the required sts module version, use "=" instead of ">="